### PR TITLE
This PR fixes a misleading sha256sum warning

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,9 @@ if ! curl -fsSLO "${SHA256_URL}"; then
 fi
 
 echo "Verifying checksum..." >&2
-sha256sum -c "${FILE}.sha256" || { echo "Error: Checksum verification failed" >&2; exit 1; }
+# Normalize checksum file (remove CRLF) and ignore empty/whitespace-only lines
+sed 's/\r$//' "${FILE}.sha256" | grep -E -v '^[[:space:]]*$' | sha256sum -c - \
+  || { echo "Error: Checksum verification failed" >&2; exit 1; }
 
 echo "Extracting archive..." >&2
 tar -xJf "$FILE"


### PR DESCRIPTION
**Summary**

This PR fixes a misleading sha256sum warning encountered during installation when verifying release artifacts.

**Problem**

During installation, the checksum verification step prints the following warning:

`sha256sum: WARNING: 1 line is improperly formatted`

even though the checksum itself is valid and the verification succeeds (OK).

This happens because the `.sha256` file published in the GitHub release contains an extra empty line at the end. While harmless, sha256sum -c treats empty or malformed lines as warnings, which can confuse users and make automated installation logs appear unreliable.

**Solution**

The checksum verification step has been updated to normalize and sanitize the .sha256 file before passing it to sha256sum:
- Remove potential CRLF line endings
- Ignore empty or whitespace-only lines
- Preserve strict checksum verification for valid entries