### PR TITLE
Split orchestration and decouple UI/output

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -26,13 +26,11 @@ pub fn extract_metadata(meta: &Value) -> ExtractedMetadata {
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let asn = meta
-        .get("asn")
-        .and_then(|v| {
-            v.as_i64()
-                .map(|n| n.to_string())
-                .or_else(|| v.as_str().map(|s| s.to_string()))
-        });
+    let asn = meta.get("asn").and_then(|v| {
+        v.as_i64()
+            .map(|n| n.to_string())
+            .or_else(|| v.as_str().map(|s| s.to_string()))
+    });
 
     let as_org = ["asOrganization", "asnOrg"]
         .iter()
@@ -40,10 +38,16 @@ pub fn extract_metadata(meta: &Value) -> ExtractedMetadata {
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    ExtractedMetadata { ip, colo, asn, as_org }
+    ExtractedMetadata {
+        ip,
+        colo,
+        asn,
+        as_org,
+    }
 }
 
 /// Network information gathered from the system
+#[derive(Debug, Clone, Default)]
 pub struct NetworkInfo {
     pub interface_name: Option<String>,
     pub network_name: Option<String>,
@@ -81,6 +85,7 @@ pub fn gather_network_info(args: &Cli) -> NetworkInfo {
 }
 
 /// Gather network interface information for the default interface
+#[allow(clippy::type_complexity)]
 fn gather_default_network_info() -> (
     Option<String>,
     Option<String>,
@@ -110,7 +115,7 @@ fn gather_default_network_info() -> (
 fn get_default_interface() -> Option<String> {
     // Try to get interface from default route
     if let Ok(output) = Command::new("ip")
-        .args(&["route", "show", "default"])
+        .args(["route", "show", "default"])
         .output()
     {
         if let Ok(output_str) = String::from_utf8(output.stdout) {
@@ -162,7 +167,7 @@ fn get_wireless_ssid(iface: &str) -> Option<String> {
     }
 
     // Fallback: try iw command
-    if let Ok(output) = Command::new("iw").args(&["dev", iface, "info"]).output() {
+    if let Ok(output) = Command::new("iw").args(["dev", iface, "info"]).output() {
         if let Ok(output_str) = String::from_utf8(output.stdout) {
             for line in output_str.lines() {
                 if line.trim().starts_with("ssid ") {

--- a/src/orchestrator/controller.rs
+++ b/src/orchestrator/controller.rs
@@ -1,0 +1,160 @@
+//! Run lifecycle controller.
+//!
+//! Owns start/stop/restart orchestration and emits events for presentation layers.
+
+use crate::cli::{build_config, Cli};
+use crate::engine::{EngineControl, TestEngine};
+use crate::model::{InfoEvent, RunConfig, RunResult, TestEvent};
+use anyhow::Result;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::time::Duration;
+
+/// Commands emitted by UI layers to control the running test.
+#[derive(Debug, Clone)]
+pub(crate) enum UiCommand {
+    Pause(bool),
+    Restart,
+    Quit,
+}
+
+/// Internal handle for a running test task.
+struct RunCtx {
+    ctrl_tx: UnboundedSender<EngineControl>,
+    handle: Option<tokio::task::JoinHandle<Result<RunResult>>>,
+}
+
+/// Spawn a new test run and return its control handle.
+fn start_run(args: &Cli, event_tx: UnboundedSender<TestEvent>) -> RunCtx {
+    let cfg: RunConfig = build_config(args);
+    let (ctrl_tx, ctrl_rx) = tokio::sync::mpsc::unbounded_channel::<EngineControl>();
+    let engine = TestEngine::new(cfg);
+    let handle = tokio::spawn(async move { engine.run(event_tx, ctrl_rx).await });
+    RunCtx {
+        ctrl_tx,
+        handle: Some(handle),
+    }
+}
+
+/// Orchestrate test runs based on UI commands and emit events back to presentation layers.
+pub(crate) async fn run_controller(
+    args: &Cli,
+    event_tx: UnboundedSender<TestEvent>,
+    mut cmd_rx: UnboundedReceiver<UiCommand>,
+) -> Result<()> {
+    let mut run_ctx = if args.test_on_launch {
+        Some(start_run(args, event_tx.clone()))
+    } else {
+        None
+    };
+    let mut restart_pending = false;
+    let mut quit_pending = false;
+    // Cancel watchdog: if a cancel takes too long, emit a status message to keep UI feedback alive.
+    let mut cancel_deadline: Option<tokio::time::Instant> = None;
+    let mut watchdog = tokio::time::interval(Duration::from_millis(500));
+
+    let res = loop {
+        tokio::select! {
+            cmd = cmd_rx.recv() => {
+                match cmd {
+                    Some(UiCommand::Pause(p)) => {
+                        if let Some(ctx) = &run_ctx {
+                            let _ = ctx.ctrl_tx.send(EngineControl::Pause(p));
+                        }
+                    }
+                    Some(UiCommand::Restart) => {
+                        // Restart is serialized: cancel the active run first, then start a new one
+                        // once we observe completion. This avoids overlapping test runs.
+                        restart_pending = true;
+                        if let Some(ctx) = &run_ctx {
+                            let _ = ctx.ctrl_tx.send(EngineControl::Cancel);
+                            let _ = event_tx.send(TestEvent::Info(InfoEvent::Message(
+                                "Cancelling…".into(),
+                            )));
+                            cancel_deadline = Some(tokio::time::Instant::now() + Duration::from_secs(3));
+                        } else {
+                            run_ctx = Some(start_run(args, event_tx.clone()));
+                            restart_pending = false;
+                            let _ = event_tx.send(TestEvent::Info(InfoEvent::Message(
+                                "Restarting…".into(),
+                            )));
+                        }
+                    }
+                    Some(UiCommand::Quit) => {
+                        // Quit waits for the current run to finish so we can cleanly finalize UI state.
+                        quit_pending = true;
+                        if let Some(ctx) = &run_ctx {
+                            let _ = ctx.ctrl_tx.send(EngineControl::Cancel);
+                            let _ = event_tx.send(TestEvent::Info(InfoEvent::Message(
+                                "Cancelling…".into(),
+                            )));
+                            cancel_deadline = Some(tokio::time::Instant::now() + Duration::from_secs(3));
+                        } else {
+                            break Ok(());
+                        }
+                    }
+                    None => {
+                        quit_pending = true;
+                        if let Some(ctx) = &run_ctx {
+                            let _ = ctx.ctrl_tx.send(EngineControl::Cancel);
+                        } else {
+                            break Ok(());
+                        }
+                    }
+                }
+            }
+            // Do not take the JoinHandle before this branch wins; otherwise it can be dropped
+            // if another select branch is chosen, and we'll never observe completion.
+            maybe_done = async {
+                if let Some(ctx) = &mut run_ctx {
+                    if let Some(h) = ctx.handle.as_mut() {
+                        return Some(h.await);
+                    }
+                }
+                futures::future::pending().await
+            } => {
+                if let Some(join_res) = maybe_done {
+                    if let Some(ctx) = &mut run_ctx {
+                        ctx.handle.take();
+                    }
+                    match join_res {
+                        Ok(Ok(r)) => {
+                            let _ = event_tx.send(TestEvent::RunCompleted { result: Box::new(r) });
+                        }
+                        Ok(Err(e)) => {
+                            let _ = event_tx.send(TestEvent::Info(InfoEvent::Message(format!(
+                                "Run failed: {e:#}"
+                            ))));
+                        }
+                        Err(e) => {
+                            let _ = event_tx.send(TestEvent::Info(InfoEvent::Message(format!(
+                                "Run join failed: {e}"
+                            ))));
+                        }
+                    }
+                    run_ctx = None;
+                    cancel_deadline = None;
+                    if quit_pending {
+                        break Ok(());
+                    }
+                    if restart_pending {
+                        run_ctx = Some(start_run(args, event_tx.clone()));
+                        restart_pending = false;
+                    }
+                }
+            }
+            // If cancel stalls (e.g., network op in flight), keep the user informed.
+            _ = watchdog.tick() => {
+                if let Some(deadline) = cancel_deadline {
+                    if tokio::time::Instant::now() >= deadline && run_ctx.is_some() {
+                        let _ = event_tx.send(TestEvent::Info(InfoEvent::Message(
+                            "Still cancelling…".into(),
+                        )));
+                        cancel_deadline = None;
+                    }
+                }
+            }
+        }
+    };
+
+    res
+}

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -1,0 +1,11 @@
+//! Application-level orchestration utilities.
+//!
+//! This module owns run lifecycle control (start/stop/restart) and post-run processing
+//! such as enrichment, auto-save, exports, and history refresh. UI/CLI layers call into
+//! this module to keep responsibilities separated.
+
+mod controller;
+mod post_process;
+
+pub(crate) use controller::{run_controller, UiCommand};
+pub(crate) use post_process::process_run_completion;

--- a/src/orchestrator/post_process.rs
+++ b/src/orchestrator/post_process.rs
@@ -1,0 +1,68 @@
+//! Post-run processing utilities.
+//!
+//! Handles enrichment, auto-save, exports, and history refresh after a run completes.
+
+use crate::cli::Cli;
+use crate::model::RunResult;
+use crate::network::{self, NetworkInfo};
+use crate::storage;
+
+/// Result of post-run processing, ready for presentation layers.
+pub(crate) struct ProcessedRun {
+    pub enriched: RunResult,
+    pub export_messages: Vec<String>,
+    pub history: Vec<RunResult>,
+    pub auto_saved_path: Option<std::path::PathBuf>,
+}
+
+/// Process a completed run: enrich with network info, auto-save, export, and reload history.
+pub(crate) fn process_run_completion(
+    args: &Cli,
+    network_info: &NetworkInfo,
+    history_load: usize,
+    auto_save: bool,
+    run: &RunResult,
+) -> ProcessedRun {
+    let mut enriched = network::enrich_result(run, network_info);
+
+    if let Some(meta) = run.meta.as_ref() {
+        let extracted = network::extract_metadata(meta);
+        enriched.ip = extracted.ip;
+        enriched.colo = extracted.colo;
+        enriched.asn = extracted.asn;
+        enriched.as_org = extracted.as_org;
+    }
+
+    if enriched.server.is_none() {
+        enriched.server = run.server.clone();
+    }
+
+    let auto_saved_path = if auto_save {
+        storage::save_run(&enriched).ok()
+    } else {
+        None
+    };
+
+    let mut export_messages = Vec::new();
+    if let Some(export_path) = args.export_json.as_deref() {
+        match storage::export_json(export_path, &enriched) {
+            Ok(_) => export_messages.push(format!("Exported JSON: {}", export_path.display())),
+            Err(e) => export_messages.push(format!("Export JSON failed: {e:#}")),
+        }
+    }
+    if let Some(export_path) = args.export_csv.as_deref() {
+        match storage::export_csv(export_path, &enriched) {
+            Ok(_) => export_messages.push(format!("Exported CSV: {}", export_path.display())),
+            Err(e) => export_messages.push(format!("Export CSV failed: {e:#}")),
+        }
+    }
+
+    let history = storage::load_recent(history_load).unwrap_or_default();
+
+    ProcessedRun {
+        enriched,
+        export_messages,
+        history,
+        auto_saved_path,
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -91,7 +91,10 @@ pub fn export_csv(path: &Path, result: &RunResult) -> Result<()> {
         csv_escape(result.network_name.as_deref().unwrap_or("")),
         result.is_wireless.map(|w| if w { "true" } else { "false" }).unwrap_or(""),
         csv_escape(result.interface_mac.as_deref().unwrap_or("")),
-        result.link_speed_mbps.map(|s| s.to_string()).unwrap_or_else(|| "".to_string()),
+        result
+            .link_speed_mbps
+            .map(|s| s.to_string())
+            .unwrap_or_default(),
     ));
     std::fs::write(path, out).context("write export csv")?;
     Ok(())

--- a/src/text_summary.rs
+++ b/src/text_summary.rs
@@ -1,0 +1,107 @@
+//! Text summary builder for CLI output.
+//!
+//! This module computes metrics and formats human-readable lines for text mode.
+
+use crate::metrics;
+use crate::model::RunResult;
+use anyhow::{Context, Result};
+
+/// Pre-formatted lines for text output.
+pub(crate) struct TextSummary {
+    pub lines: Vec<String>,
+}
+
+/// Build a text summary from enriched results and raw samples.
+pub(crate) fn build_text_summary(
+    enriched: &RunResult,
+    dl_points: &[(f64, f64)],
+    ul_points: &[(f64, f64)],
+    idle_latency_samples: &[f64],
+    loaded_dl_latency_samples: &[f64],
+    loaded_ul_latency_samples: &[f64],
+) -> Result<TextSummary> {
+    let mut lines = Vec::new();
+
+    if let Some(meta) = enriched.meta.as_ref() {
+        let extracted = crate::network::extract_metadata(meta);
+        let ip = extracted.ip.as_deref().unwrap_or("-");
+        let colo = extracted.colo.as_deref().unwrap_or("-");
+        let asn = extracted.asn.as_deref().unwrap_or("-");
+        let org = extracted.as_org.as_deref().unwrap_or("-");
+        lines.push(format!("IP/Colo/ASN: {ip} / {colo} / {asn} ({org})"));
+    }
+    if let Some(server) = enriched.server.as_deref() {
+        lines.push(format!("Server: {server}"));
+    }
+    if let Some(comments) = enriched.comments.as_deref() {
+        if !comments.trim().is_empty() {
+            lines.push(format!("Comments: {}", comments));
+        }
+    }
+
+    let dl_values: Vec<f64> = dl_points.iter().map(|(_, y)| *y).collect();
+    let (dl_mean, dl_median, dl_p25, dl_p75) = metrics::compute_metrics(&dl_values)
+        .context("insufficient download throughput data to compute metrics")?;
+    lines.push(format!(
+        "Download: avg {:.2} med {:.2} p25 {:.2} p75 {:.2}",
+        dl_mean, dl_median, dl_p25, dl_p75
+    ));
+
+    let ul_values: Vec<f64> = ul_points.iter().map(|(_, y)| *y).collect();
+    let (ul_mean, ul_median, ul_p25, ul_p75) = metrics::compute_metrics(&ul_values)
+        .context("insufficient upload throughput data to compute metrics")?;
+    lines.push(format!(
+        "Upload:   avg {:.2} med {:.2} p25 {:.2} p75 {:.2}",
+        ul_mean, ul_median, ul_p25, ul_p75
+    ));
+
+    let (idle_mean, idle_median, idle_p25, idle_p75) =
+        metrics::compute_metrics(idle_latency_samples)
+            .context("insufficient idle latency data to compute metrics")?;
+    lines.push(format!(
+        "Idle latency: avg {:.1} med {:.1} p25 {:.1} p75 {:.1} ms (loss {:.1}%, jitter {:.1} ms)",
+        idle_mean,
+        idle_median,
+        idle_p25,
+        idle_p75,
+        enriched.idle_latency.loss * 100.0,
+        enriched.idle_latency.jitter_ms.unwrap_or(f64::NAN)
+    ));
+
+    let (dl_lat_mean, dl_lat_median, dl_lat_p25, dl_lat_p75) =
+        metrics::compute_metrics(loaded_dl_latency_samples)
+            .context("insufficient loaded download latency data to compute metrics")?;
+    lines.push(format!(
+        "Loaded latency (download): avg {:.1} med {:.1} p25 {:.1} p75 {:.1} ms (loss {:.1}%, jitter {:.1} ms)",
+        dl_lat_mean,
+        dl_lat_median,
+        dl_lat_p25,
+        dl_lat_p75,
+        enriched.loaded_latency_download.loss * 100.0,
+        enriched.loaded_latency_download.jitter_ms.unwrap_or(f64::NAN)
+    ));
+
+    let (ul_lat_mean, ul_lat_median, ul_lat_p25, ul_lat_p75) =
+        metrics::compute_metrics(loaded_ul_latency_samples)
+            .context("insufficient loaded upload latency data to compute metrics")?;
+    lines.push(format!(
+        "Loaded latency (upload): avg {:.1} med {:.1} p25 {:.1} p75 {:.1} ms (loss {:.1}%, jitter {:.1} ms)",
+        ul_lat_mean,
+        ul_lat_median,
+        ul_lat_p25,
+        ul_lat_p75,
+        enriched.loaded_latency_upload.loss * 100.0,
+        enriched.loaded_latency_upload.jitter_ms.unwrap_or(f64::NAN)
+    ));
+
+    if let Some(ref exp) = enriched.experimental_udp {
+        lines.push(format!(
+            "Experimental UDP-like loss probe: loss {:.1}% med {} ms (target {:?})",
+            exp.latency.loss * 100.0,
+            exp.latency.median_ms.unwrap_or(f64::NAN),
+            exp.target
+        ));
+    }
+
+    Ok(TextSummary { lines })
+}

--- a/src/tui/charts.rs
+++ b/src/tui/charts.rs
@@ -158,16 +158,28 @@ fn render_metrics_text<'a>(
 }
 
 /// Helper function to render a throughput chart with metrics inside the same bordered box
-pub fn render_chart_with_metrics_inside(
-    f: &mut Frame,
-    area: Rect,
-    datasets: Vec<Dataset>,
-    x_axis: ratatui::widgets::Axis,
-    y_axis: ratatui::widgets::Axis,
-    title: Line,
-    metrics: Option<(f64, f64, f64, f64)>,
-    color: Color,
-) {
+/// Parameters for rendering a chart with embedded metrics.
+pub(crate) struct ChartRenderParams<'a> {
+    pub area: Rect,
+    pub datasets: Vec<Dataset<'a>>,
+    pub x_axis: ratatui::widgets::Axis<'a>,
+    pub y_axis: ratatui::widgets::Axis<'a>,
+    pub title: Line<'a>,
+    pub metrics: Option<(f64, f64, f64, f64)>,
+    pub color: Color,
+}
+
+/// Render a chart with metrics inside a shared bordered area.
+pub(crate) fn render_chart_with_metrics_inside(f: &mut Frame, params: ChartRenderParams<'_>) {
+    let ChartRenderParams {
+        area,
+        datasets,
+        x_axis,
+        y_axis,
+        title,
+        metrics,
+        color,
+    } = params;
     // Get inner area (accounting for borders)
     let inner = if area.width > 2 && area.height > 2 {
         Rect {


### PR DESCRIPTION
### Why

- The app did synchronous stdout/stderr writes inside async code paths, which can introduce jitter and block the Tokio runtime.
- TUI rendering and input handling were running in async tasks and invoked blocking terminal I/O, which can stall worker threads.
- Responsibilities (export/save, network info gathering, run orchestration) were mixed into UI/CLI code.

### What changed

- CLI output (text/json/errors) is routed through a dedicated writer running in spawn_blocking, removing synchronous I/O from hot async paths.
- TUI is moved into a dedicated thread; it owns the terminal and performs blocking draw/input without touching Tokio workers.
- Event flow uses unbounded Tokio channels to avoid backpressure and task switching in the measurement hot path.
- Added a RunCompleted event (boxed) to deliver results to the UI thread cleanly.
- Added cancellation status feedback (e.g., “Cancelling…”, “Still cancelling…”) to keep UI responsive during long cancels.
- Fixed a potential race where a JoinHandle could be dropped before completion was observed.
- Split orchestration into controller (run lifecycle) and post-processing (export/auto-save/history), with UI only sending commands.
- Gathered NetworkInfo outside the UI thread and passed it in (UI only consumes results).
- Refactored text-mode summaries into a separate builder for presentation-only output.
- Shifted Summary phase update to occur right after upload timing ends to avoid UI “stuck on upload” delays.
- Text mode output now flushes per line (LineWriter) for real-time progress.

### Why these choices

- spawn_blocking is the recommended way to perform blocking I/O from async code.
- A dedicated UI thread is the safest way to keep terminal I/O fully outside Tokio.
- Unbounded channels fit our bounded event volume and avoid artificial throttling of measurements.
- Splitting orchestration keeps UI/CLI focused on presentation and reduces cross-layer coupling.

### Impact

- Measurements are less likely to be affected by output rendering or logging.
- UI remains responsive and isolated from async scheduling.
- Code paths are clearer: async for network/engine, sync for UI/terminal.
- Text mode now renders incremental output reliably.