### PR TITLE
Enable macOS to detect the network interface, SSID, and MAC address

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ You can read more about how Cloudflare's speedtest works [here](https://speed.cl
 ## Outstanding Issues
 
 - Network information on Windows is incomplete. I haven't used Windows (outside gaming) in many years and unless there's demand for it I likely won't implement this part. Feel free to open a PR or an issue and we can chat. Honestly the only reason there's a Windows binary at all is because ['cargo-dist'](https://github.com/axodotdev/cargo-dist) made it so easy to do so.
+- Unable to detect the SSID on macOS Sonoma 14.4 and later as this is now considered location-sensitive data.
 
 ## Contributing
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -3,6 +3,12 @@ use crate::model::RunResult;
 use serde_json::Value;
 use std::process::Command;
 
+/// Path to the legacy macOS airport CLI. Apple removed this binary in macOS 14.4 (Sonoma),
+/// so it is only useful as a fallback on macOS 13 and earlier.
+#[cfg(target_os = "macos")]
+const MACOS_AIRPORT_PATH: &str =
+    "/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport";
+
 /// Extracted metadata fields from Cloudflare response
 #[derive(Debug, Clone, Default)]
 pub struct ExtractedMetadata {
@@ -112,7 +118,7 @@ fn gather_default_network_info() -> (Option<String>, Option<String>, Option<bool
 }
 
 /// Get the default network interface name
-#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+#[cfg(target_os = "linux")]
 fn get_default_interface() -> Option<String> {
     // Try to get interface from default route
     if let Ok(output) = Command::new("ip")
@@ -169,6 +175,24 @@ fn get_default_interface() -> Option<String> {
         }
     }
 
+    // Fallback: first non-loopback, non-tunnel interface from the system
+    if let Ok(interfaces) = if_addrs::get_if_addrs() {
+        for iface in interfaces {
+            if iface.is_loopback() {
+                continue;
+            }
+            // Skip common virtual/tunnel interfaces
+            if iface.name.starts_with("utun")
+                || iface.name.starts_with("awdl")
+                || iface.name.starts_with("llw")
+                || iface.name.starts_with("bridge")
+            {
+                continue;
+            }
+            return Some(iface.name);
+        }
+    }
+
     None
 }
 
@@ -211,7 +235,7 @@ fn get_default_interface() -> Option<String> {
 }
 
 /// Check if interface is wireless
-#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+#[cfg(target_os = "linux")]
 fn check_if_wireless(iface: &str) -> Option<bool> {
     // Check if /sys/class/net/<iface>/wireless exists
     let wireless_path = format!("/sys/class/net/{}/wireless", iface);
@@ -221,25 +245,29 @@ fn check_if_wireless(iface: &str) -> Option<bool> {
 #[cfg(target_os = "macos")]
 fn check_if_wireless(iface: &str) -> Option<bool> {
     // Parse `networksetup -listallhardwareports` to check if the interface is Wi-Fi
-    if let Ok(output) = Command::new("networksetup").arg("-listallhardwareports").output() {
-        if let Ok(output_str) = String::from_utf8(output.stdout) {
-            let mut is_wifi_section = false;
-            for line in output_str.lines() {
-                let line = line.trim();
-                if line.starts_with("Hardware Port:") {
-                    let port_name = line.splitn(2, ':').nth(1).unwrap_or("").trim().to_lowercase();
-                    is_wifi_section = port_name.contains("wi-fi") || port_name.contains("airport");
-                } else if line.starts_with("Device:") {
-                    if let Some(device) = line.splitn(2, ':').nth(1) {
-                        if device.trim() == iface {
-                            return Some(is_wifi_section);
-                        }
-                    }
+    let output = Command::new("networksetup")
+        .arg("-listallhardwareports")
+        .output()
+        .ok()?;
+    let output_str = String::from_utf8(output.stdout).ok()?;
+
+    let mut is_wifi_section = false;
+    for line in output_str.lines() {
+        let line = line.trim();
+        if line.starts_with("Hardware Port:") {
+            let port_name = line.splitn(2, ':').nth(1).unwrap_or("").trim().to_lowercase();
+            is_wifi_section = port_name.contains("wi-fi") || port_name.contains("airport");
+        } else if line.starts_with("Device:") {
+            if let Some(device) = line.splitn(2, ':').nth(1) {
+                if device.trim() == iface {
+                    return Some(is_wifi_section);
                 }
             }
         }
     }
-    Some(false)
+
+    // Interface wasn't listed (e.g. utun/VPN); we don't know, so return None
+    None
 }
 
 #[cfg(target_os = "windows")]
@@ -257,7 +285,7 @@ fn check_if_wireless(iface: &str) -> Option<bool> {
 }
 
 /// Get wireless SSID for an interface
-#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+#[cfg(target_os = "linux")]
 fn get_wireless_ssid(iface: &str) -> Option<String> {
     // Try iwgetid first (most reliable)
     if let Ok(output) = Command::new("iwgetid").arg("-r").arg(iface).output() {
@@ -304,9 +332,8 @@ fn get_wireless_ssid(iface: &str) -> Option<String> {
         }
     }
 
-    // Fallback: try the airport command (deprecated in newer macOS but widely available)
-    let airport = "/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport";
-    if let Ok(output) = Command::new(airport).arg("-I").output() {
+    // Fallback: try the legacy airport command (removed in macOS 14.4, but works on older versions)
+    if let Ok(output) = Command::new(MACOS_AIRPORT_PATH).arg("-I").output() {
         if let Ok(output_str) = String::from_utf8(output.stdout) {
             for line in output_str.lines() {
                 let line = line.trim();
@@ -356,7 +383,7 @@ fn get_wireless_ssid(iface: &str) -> Option<String> {
 }
 
 /// Get MAC address of interface
-#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+#[cfg(target_os = "linux")]
 fn get_interface_mac(iface: &str) -> Option<String> {
     let mac_path = format!("/sys/class/net/{}/address", iface);
     std::fs::read_to_string(mac_path)

--- a/src/network.rs
+++ b/src/network.rs
@@ -112,7 +112,7 @@ fn gather_default_network_info() -> (Option<String>, Option<String>, Option<bool
 }
 
 /// Get the default network interface name
-#[cfg(not(windows))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 fn get_default_interface() -> Option<String> {
     // Try to get interface from default route
     if let Ok(output) = Command::new("ip")
@@ -148,7 +148,31 @@ fn get_default_interface() -> Option<String> {
     None
 }
 
-#[cfg(windows)]
+#[cfg(target_os = "macos")]
+fn get_default_interface() -> Option<String> {
+    // Use `route -n get default` to find the default interface
+    if let Ok(output) = Command::new("route").args(&["-n", "get", "default"]).output() {
+        if output.status.success() {
+            if let Ok(output_str) = String::from_utf8(output.stdout) {
+                for line in output_str.lines() {
+                    let line = line.trim();
+                    if line.starts_with("interface:") {
+                        if let Some(iface) = line.splitn(2, ':').nth(1) {
+                            let iface = iface.trim().to_string();
+                            if !iface.is_empty() {
+                                return Some(iface);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "windows")]
 fn get_default_interface() -> Option<String> {
     let output = Command::new("powershell")
         .args(&[
@@ -187,14 +211,38 @@ fn get_default_interface() -> Option<String> {
 }
 
 /// Check if interface is wireless
-#[cfg(not(windows))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 fn check_if_wireless(iface: &str) -> Option<bool> {
     // Check if /sys/class/net/<iface>/wireless exists
     let wireless_path = format!("/sys/class/net/{}/wireless", iface);
     Some(std::path::Path::new(&wireless_path).exists())
 }
 
-#[cfg(windows)]
+#[cfg(target_os = "macos")]
+fn check_if_wireless(iface: &str) -> Option<bool> {
+    // Parse `networksetup -listallhardwareports` to check if the interface is Wi-Fi
+    if let Ok(output) = Command::new("networksetup").arg("-listallhardwareports").output() {
+        if let Ok(output_str) = String::from_utf8(output.stdout) {
+            let mut is_wifi_section = false;
+            for line in output_str.lines() {
+                let line = line.trim();
+                if line.starts_with("Hardware Port:") {
+                    let port_name = line.splitn(2, ':').nth(1).unwrap_or("").trim().to_lowercase();
+                    is_wifi_section = port_name.contains("wi-fi") || port_name.contains("airport");
+                } else if line.starts_with("Device:") {
+                    if let Some(device) = line.splitn(2, ':').nth(1) {
+                        if device.trim() == iface {
+                            return Some(is_wifi_section);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Some(false)
+}
+
+#[cfg(target_os = "windows")]
 fn check_if_wireless(iface: &str) -> Option<bool> {
     let output = Command::new("netsh")
         .args(&["wlan", "show", "interfaces"])
@@ -209,7 +257,7 @@ fn check_if_wireless(iface: &str) -> Option<bool> {
 }
 
 /// Get wireless SSID for an interface
-#[cfg(not(windows))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 fn get_wireless_ssid(iface: &str) -> Option<String> {
     // Try iwgetid first (most reliable)
     if let Ok(output) = Command::new("iwgetid").arg("-r").arg(iface).output() {
@@ -238,7 +286,46 @@ fn get_wireless_ssid(iface: &str) -> Option<String> {
     None
 }
 
-#[cfg(windows)]
+#[cfg(target_os = "macos")]
+fn get_wireless_ssid(iface: &str) -> Option<String> {
+    // Try `networksetup -getairportnetwork <iface>` (public API)
+    if let Ok(output) = Command::new("networksetup")
+        .args(&["-getairportnetwork", iface])
+        .output()
+    {
+        if let Ok(output_str) = String::from_utf8(output.stdout) {
+            let output_str = output_str.trim();
+            if let Some(ssid) = output_str.strip_prefix("Current Wi-Fi Network:") {
+                let ssid = ssid.trim().to_string();
+                if !ssid.is_empty() {
+                    return Some(ssid);
+                }
+            }
+        }
+    }
+
+    // Fallback: try the airport command (deprecated in newer macOS but widely available)
+    let airport = "/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport";
+    if let Ok(output) = Command::new(airport).arg("-I").output() {
+        if let Ok(output_str) = String::from_utf8(output.stdout) {
+            for line in output_str.lines() {
+                let line = line.trim();
+                if line.starts_with("SSID:") {
+                    if let Some(ssid) = line.splitn(2, ':').nth(1) {
+                        let ssid = ssid.trim().to_string();
+                        if !ssid.is_empty() {
+                            return Some(ssid);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "windows")]
 fn get_wireless_ssid(iface: &str) -> Option<String> {
     let output = Command::new("netsh")
         .args(&["wlan", "show", "interfaces"])
@@ -269,7 +356,7 @@ fn get_wireless_ssid(iface: &str) -> Option<String> {
 }
 
 /// Get MAC address of interface
-#[cfg(not(windows))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 fn get_interface_mac(iface: &str) -> Option<String> {
     let mac_path = format!("/sys/class/net/{}/address", iface);
     std::fs::read_to_string(mac_path)
@@ -278,7 +365,27 @@ fn get_interface_mac(iface: &str) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-#[cfg(windows)]
+#[cfg(target_os = "macos")]
+fn get_interface_mac(iface: &str) -> Option<String> {
+    // Use `ifconfig <iface>` and parse the `ether` line
+    if let Ok(output) = Command::new("ifconfig").arg(iface).output() {
+        if output.status.success() {
+            if let Ok(output_str) = String::from_utf8(output.stdout) {
+                for line in output_str.lines() {
+                    let line = line.trim();
+                    if line.starts_with("ether ") {
+                        if let Some(mac) = line.split_whitespace().nth(1) {
+                            return Some(mac.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "windows")]
 fn get_interface_mac(iface: &str) -> Option<String> {
     let output = Command::new("powershell")
         .args(&[


### PR DESCRIPTION
This pull request partially addresses the issue reported in #39, where the `network interface`, `SSID`, and `MAC address` are incorrectly reported on macOS. This information is accessed in a slightly different manner to Linux, and I think this is the cause of the issue.

On my test machines, this pull request updates the information reported from:

| Machine          | Connection | Interface | Network | MAC address |
| ---------------- | ---------- | --------- | ------- | ----------- |
| Tahoe / 26       | wired      | `(Wired)` | EMPTY-1 |   EMPTY-2   |
| Tahoe / 26       | wireless   | `(Wired)` | EMPTY-1 |   EMPTY-2   |
| Monterey / 12    | wireless   | `(Wired)` | EMPTY-1 |   EMPTY-2   |
| Catalina / 10.15 | wireless   | `(Wired)` | EMPTY-1 |   EMPTY-2   |

- EMPTY-1 = nothing displayed after `Network -`.
- EMPTY-2 = nothing displayed after `MAC address -`.

to:

| Machine          | Connection | Interface        | Network     | MAC address    |
| ---------------- | ---------- | ---------------- | ----------- | -------------- |
| Tahoe / 26       | wired      | `en9 (Wired)`    | `en9` (*)   | `MyMACAddress` |
| Tahoe / 26       | wireless   | `en0 (Wireless)` | `en0` (^)   | `MyMACAddress` |
| Monterey / 12    | wireless   | `en0 (Wireless)` | `MySSID`    | `MyMACAddress` |
| Catalina / 10.15 | wireless   | `en0 (Wireless)` | `MySSID`    | `MyMACAddress` |


- (*) I think the code suggests when the netork can't be identified to fall back on the interface, so I think this is expected behaviour for all platforms?
- (^) There is an issue identifying the SSID on macOS Sonoma 14.4 and later, as this is now considered location-sensitive data. There are some work arounds reported, but it seems Apple have been tightening up on these, and I couldn't get anything to work. I believe developers are able to access this information if the app is a signed download from the app store / the user accepts the app's request for this information – I don't think this is possible from a CLI app.

  One way to demonstrate the inability to access the SSID on macOS 26 is by running:
  ```bash
  iface=$(scutil --nwi | egrep -om1 'en\d')
  ipconfig getsummary $iface | awk '/SSID|Security|yiaddr/ {sub(/yiaddr/,"IP",$1);printf "%-10s%-18s\n", $1,$3}'
  ```
  which returns:
  ```bash
  BSSID     <redacted>        
  IP        192.168.0.60      
  SSID      <redacted>        
  Security  WPA2_PSK 
  ```
  where `<redacted>` is what is actually displayed.


**Summary**

- **Interface**: successfully detected and displayed on all tested macOS ✅
- **MAC addreess**: successfully detected and displayed on all tested macOS ✅
- **SSID**: successfully detected and displayed on macOS 13 (Ventura) and earlier ✅. On macOS 14 (Sonoma) and later it is no longer possible to access the SSID, so the app's default value of the network interface is displayed. 


I don't really speak `Rust` so you might need to tidy this code up ;-) Let me know if you'd like me to do any testing on macOS following any updates.

Cheers,
Chris