### PR TITLE
Fix build and add proper platform-specific code for FreeBSD

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -154,6 +154,34 @@ fn get_default_interface() -> Option<String> {
     None
 }
 
+#[cfg(target_os = "freebsd")]
+fn get_default_interface() -> Option<String> {
+    let output = Command::new("netstat")
+        .args(&["-rn", "--libxo=json"])
+        .output()
+        .ok()?;
+
+    let output_str = String::from_utf8(output.stdout).ok()?;
+    let _v: Value = serde_json::from_str(&output_str).ok()?;
+
+    if let Some(families) = _v["statistics"]["route-information"]["route-table"]["rt-family"].as_array() {
+        for family in families {
+            if let Some("Internet" | "Internet6") = family["address-family"].as_str() {
+                if let Some(entries) = family["rt-entry"].as_array() {
+                    for entry in entries {
+                        if entry["destination"].as_str() == Some("default") {
+                            let interface = entry["interface-name"].as_str();
+                            return Some(interface?.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
 #[cfg(target_os = "macos")]
 fn get_default_interface() -> Option<String> {
     // Use `route -n get default` to find the default interface
@@ -242,6 +270,23 @@ fn check_if_wireless(iface: &str) -> Option<bool> {
     Some(std::path::Path::new(&wireless_path).exists())
 }
 
+#[cfg(target_os = "freebsd")]
+fn check_if_wireless(iface: &str) -> Option<bool> {
+    // An very quick and dirty wireless check for FreeBSD
+    // but it works
+    let output = Command::new("ifconfig")
+        .args(&["-g", "wlan"])
+        .output()
+        .ok()?;
+    let output_str = String::from_utf8(output.stdout).ok()?;
+
+    let is_wireless = output_str
+        .lines()
+        .any(|line| line.trim() == iface);
+
+    Some(is_wireless)
+}
+
 #[cfg(target_os = "macos")]
 fn check_if_wireless(iface: &str) -> Option<bool> {
     // Parse `networksetup -listallhardwareports` to check if the interface is Wi-Fi
@@ -307,6 +352,34 @@ fn get_wireless_ssid(iface: &str) -> Option<String> {
                         return Some(ssid.to_string());
                     }
                 }
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_os = "freebsd")]
+fn get_wireless_ssid(iface: &str) -> Option<String> {
+    let output = Command::new("ifconfig")
+        .arg(iface)
+        .output()
+        .ok()?;
+
+    let output_str = String::from_utf8_lossy(&output.stdout);
+
+    for line in output_str.lines() {
+        if let Some(idx) = line.find("ssid ") {
+            let rest = line[idx + 5..].trim_start();
+
+            if rest.starts_with('"') {
+                // ssid "an example ssid" channel 1 ...
+                let end_idx = rest[1..].find('"')?;
+                return Some(rest[1..end_idx + 1].to_string());
+            } else {
+                // ssid an_example_ssid channel 1 ...
+                let end_idx = rest.find(' ').unwrap_or(rest.len());
+                return Some(rest[..end_idx].to_string());
             }
         }
     }
@@ -392,7 +465,8 @@ fn get_interface_mac(iface: &str) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+// The same code works both for macOS and FreeBSD
 fn get_interface_mac(iface: &str) -> Option<String> {
     // Use `ifconfig <iface>` and parse the `ether` line
     if let Ok(output) = Command::new("ifconfig").arg(iface).output() {

--- a/src/network.rs
+++ b/src/network.rs
@@ -366,20 +366,40 @@ fn get_wireless_ssid(iface: &str) -> Option<String> {
         .output()
         .ok()?;
 
+    if !output.status.success() {
+        return None;
+    }
+
     let output_str = String::from_utf8_lossy(&output.stdout);
 
     for line in output_str.lines() {
-        if let Some(idx) = line.find("ssid ") {
-            let rest = line[idx + 5..].trim_start();
+        let mut tokens = line.split_whitespace();
 
-            if rest.starts_with('"') {
-                // ssid "an example ssid" channel 1 ...
-                let end_idx = rest[1..].find('"')?;
-                return Some(rest[1..end_idx + 1].to_string());
-            } else {
-                // ssid an_example_ssid channel 1 ...
-                let end_idx = rest.find(' ').unwrap_or(rest.len());
-                return Some(rest[..end_idx].to_string());
+        while let Some(tok) = tokens.next() {
+            if tok == "ssid" || tok == "meshid" {
+                if let Some(next_tok) = tokens.next() {
+                    if next_tok.starts_with('"') {
+                        // If the SSID contains whitespace, it's double quoted
+                        // ssid "an example ssid" channel 1 ...
+                        let mut ssid = next_tok.trim_start_matches('"').to_string();
+
+                        for next_tok in tokens.by_ref() {
+                            ssid.push(' ');
+                            if next_tok.ends_with('"') {
+                                ssid.push_str(next_tok.trim_end_matches('"'));
+                                break;
+                            } else {
+                                ssid.push_str(next_tok);
+                            }
+                        }
+
+                        return Some(ssid);
+                    } else {
+                        // No double quotation if no white space
+                        // ssid an_example_ssid channel 1 ...
+                        return Some(next_tok.to_string());
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Fix build and add proper platform-specific code for FreeBSD

Fllowing #40,the build fails on FreeBSD due to missing platform-specific function implementations. Additionally, get_default_interface() was broken on FreeBSD because its previous implementation assumed Linux, despite using `#[cfg(not(windows))]`.

This commit implements the following platform-specific functions for FreeBSD to correctly retrieve the interface name, network SSID, and MAC address:
- get_default_interface()
- check_if_wireless()
- get_wireless_ssid()
- get_interface_mac() (supports both macOS and FreeBSD with no change)

----

### Through v0.6.11

<img width="1734" height="1431" alt="image" src="https://github.com/user-attachments/assets/ce3934be-20c1-499c-b3ae-618637eda93b" />

###  This PR

<img width="1734" height="1431" alt="image" src="https://github.com/user-attachments/assets/9d4348d6-178c-42f8-a6f1-82859abcc606" />

### This PR (Wireless)

It properly retrieves the wireless network SSID as well.

<img width="1940" height="1089" alt="image" src="https://github.com/user-attachments/assets/85f56ea4-353e-4145-888a-6f14f48bfd42" />
