### PR TITLE
wire up --ipv4-only / --ipv6-only flags

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::engine::{EngineControl, TestEngine};
-use crate::model::{RunConfig, TestEvent};
+use crate::model::{IpVersionFilter, RunConfig, TestEvent};
 use anyhow::{Context, Result};
 use clap::Parser;
 use rand::RngCore;
@@ -114,11 +114,11 @@ pub struct Cli {
     pub traceroute_max_hops: u8,
 
     /// Force IPv4 only (no IPv6)
-    #[arg(long)]
+    #[arg(long, conflicts_with_all = ["ipv6_only", "compare_ip_versions"])]
     pub ipv4_only: bool,
 
     /// Force IPv6 only (no IPv4)
-    #[arg(long)]
+    #[arg(long, conflicts_with_all = ["ipv4_only", "compare_ip_versions"])]
     pub ipv6_only: bool,
 
     /// Skip default diagnostic measurements (DNS, TLS)
@@ -189,10 +189,21 @@ pub fn build_config(args: &Cli) -> Result<RunConfig> {
     // DNS and TLS run by default unless --skip-diagnostics is set
     let skip = args.skip_diagnostics;
 
-    // Resolve bind address once from --interface or --source
+    let ip_version = if args.ipv4_only {
+        IpVersionFilter::V4Only
+    } else if args.ipv6_only {
+        IpVersionFilter::V6Only
+    } else {
+        IpVersionFilter::Auto
+    };
+
+    // Resolve bind address once from --interface or --source.
+    // Pass the IP-version filter so an interface lookup picks the matching family
+    // and a --source IP whose family conflicts is rejected.
     let resolved_bind_ip = network_bind::resolve_bind_address(
         args.interface.as_ref(),
         args.source.as_ref(),
+        ip_version,
     )?
     .map(|addr| addr.ip());
 
@@ -202,6 +213,18 @@ pub fn build_config(args: &Cli) -> Result<RunConfig> {
         } else {
             eprintln!("Binding HTTP connections to source IP: {}", ip);
         }
+    }
+
+    // A proxy terminates our connection and performs its own DNS/dialing, so we
+    // cannot pin the address family for traffic routed through it. Direct
+    // measurements (TLS, UDP, traceroute) still honour the filter, so warn
+    // rather than error.
+    if args.proxy.is_some() && ip_version != IpVersionFilter::Auto {
+        eprintln!(
+            "warning: --{}-only cannot be enforced for HTTP traffic routed through --proxy; \
+             the proxy selects the address family for those requests",
+            ip_version.label().to_lowercase()
+        );
     }
 
     Ok(RunConfig {
@@ -229,8 +252,7 @@ pub fn build_config(args: &Cli) -> Result<RunConfig> {
         compare_ip_versions: args.compare_ip_versions,
         traceroute: args.traceroute,
         traceroute_max_hops: args.traceroute_max_hops,
-        ipv4_only: args.ipv4_only,
-        ipv6_only: args.ipv6_only,
+        ip_version,
         udp_packets: args.udp_packets,
     })
 }

--- a/src/engine/cloudflare.rs
+++ b/src/engine/cloudflare.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
 use reqwest::Url;
+use std::net::SocketAddr;
 use std::time::Duration;
 
-use crate::model::RunConfig;
+use crate::model::{IpVersionFilter, RunConfig};
 
 #[derive(Clone)]
 pub struct CloudflareClient {
@@ -12,7 +13,7 @@ pub struct CloudflareClient {
 }
 
 impl CloudflareClient {
-    pub fn new(cfg: &RunConfig) -> Result<Self> {
+    pub async fn new(cfg: &RunConfig) -> Result<Self> {
         let base_url = Url::parse(&cfg.base_url).context("invalid base_url")?;
 
         let mut default_headers = reqwest::header::HeaderMap::new();
@@ -30,6 +31,32 @@ impl CloudflareClient {
             .tcp_keepalive(Duration::from_secs(15));
 
         builder = network_bind::apply_local_address(builder, cfg.resolved_bind_ip);
+
+        // Constrain DNS resolution to the requested IP version by pre-resolving
+        // the base host and pinning reqwest's resolver to the matching addresses.
+        if cfg.ip_version != IpVersionFilter::Auto {
+            let host = base_url
+                .host_str()
+                .context("base_url has no host")?
+                .to_string();
+            let port = base_url.port_or_known_default().unwrap_or(443);
+            let lookup = format!("{}:{}", host, port);
+            let addrs: Vec<SocketAddr> = tokio::net::lookup_host(&lookup)
+                .await
+                .with_context(|| format!("DNS lookup failed for {}", host))?
+                .filter(|a| cfg.ip_version.allows_socket(*a))
+                .collect();
+
+            if addrs.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "DNS returned no {} addresses for {}",
+                    cfg.ip_version.label(),
+                    host
+                ));
+            }
+
+            builder = builder.resolve_to_addrs(&host, &addrs);
+        }
 
         // Load custom certificate if provided
         if let Some(ref cert_path) = cfg.certificate_path {

--- a/src/engine/dns.rs
+++ b/src/engine/dns.rs
@@ -1,6 +1,6 @@
 //! DNS resolution time measurement module
 
-use crate::model::DnsSummary;
+use crate::model::{DnsSummary, IpVersionFilter};
 use anyhow::{Context, Result};
 use std::net::IpAddr;
 use std::time::Instant;
@@ -208,10 +208,14 @@ pub fn extract_hostname(url: &str) -> Option<String> {
 
 /// Fetch external IPv4 and IPv6 addresses by making requests to Cloudflare.
 /// Returns (ipv4, ipv6) - either may be None if not available.
+///
+/// The `filter` parameter skips fetches for versions that have been disabled
+/// by `--ipv4-only` / `--ipv6-only`.
 pub async fn fetch_external_ips(
     base_url: &str,
     bind_ip: Option<std::net::IpAddr>,
     cert_path: Option<&std::path::Path>,
+    filter: IpVersionFilter,
 ) -> (Option<String>, Option<String>) {
     let hostname = match extract_hostname(base_url) {
         Some(h) => h,
@@ -221,9 +225,24 @@ pub async fn fetch_external_ips(
     // Resolve to get IPv4 and IPv6 addresses
     let url = format!("{}/__down?bytes=0", base_url);
 
+    let want_v4 = matches!(filter, IpVersionFilter::Auto | IpVersionFilter::V4Only);
+    let want_v6 = matches!(filter, IpVersionFilter::Auto | IpVersionFilter::V6Only);
+
     let (ipv4, ipv6) = tokio::join!(
-        fetch_external_ip_version(&url, &hostname, IpVersion::V4, bind_ip, cert_path),
-        fetch_external_ip_version(&url, &hostname, IpVersion::V6, bind_ip, cert_path)
+        async {
+            if want_v4 {
+                fetch_external_ip_version(&url, &hostname, IpVersion::V4, bind_ip, cert_path).await
+            } else {
+                None
+            }
+        },
+        async {
+            if want_v6 {
+                fetch_external_ip_version(&url, &hostname, IpVersion::V6, bind_ip, cert_path).await
+            } else {
+                None
+            }
+        }
     );
 
     (ipv4, ipv6)

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,8 +10,8 @@ pub mod traceroute;
 mod turn_udp;
 
 use crate::model::{
-    DnsSummary, IpVersionComparison, Phase, RunConfig, RunResult, TestEvent, TlsSummary,
-    TracerouteSummary,
+    DnsSummary, IpVersionComparison, IpVersionFilter, Phase, RunConfig, RunResult, TestEvent,
+    TlsSummary, TracerouteSummary,
 };
 use anyhow::Result;
 use std::sync::{
@@ -52,7 +52,7 @@ impl TestEngine {
         event_tx: mpsc::Sender<TestEvent>,
         mut control_rx: mpsc::Receiver<EngineControl>,
     ) -> Result<RunResult> {
-        let client = cloudflare::CloudflareClient::new(&self.cfg)?;
+        let client = cloudflare::CloudflareClient::new(&self.cfg).await?;
 
         let paused = Arc::new(AtomicBool::new(false));
         let cancel = Arc::new(AtomicBool::new(false));
@@ -189,6 +189,7 @@ impl TestEngine {
                     port,
                     self.cfg.certificate_path.as_deref(),
                     self.cfg.resolved_bind_ip,
+                    self.cfg.ip_version,
                 )
                 .await
                 {
@@ -213,12 +214,14 @@ impl TestEngine {
             }
         }
 
-        // Fetch external IPs (runs in parallel, part of default diagnostics)
+        // Fetch external IPs (runs in parallel, part of default diagnostics).
+        // Honour --ipv4-only / --ipv6-only by skipping the disabled family entirely.
         if self.cfg.measure_dns {
             let (v4, v6) = dns::fetch_external_ips(
                 &self.cfg.base_url,
                 self.cfg.resolved_bind_ip,
                 self.cfg.certificate_path.as_deref(),
+                self.cfg.ip_version,
             )
             .await;
             external_ipv4 = v4.clone();
@@ -229,8 +232,9 @@ impl TestEngine {
                 .ok();
         }
 
-        // IPv4 vs IPv6 comparison
-        if self.cfg.compare_ip_versions {
+        // IPv4 vs IPv6 comparison. Clap rejects this combined with --ipv4-only/--ipv6-only,
+        // but guard defensively in case the engine is invoked outside the CLI.
+        if self.cfg.compare_ip_versions && self.cfg.ip_version == IpVersionFilter::Auto {
             event_tx
                 .send(TestEvent::Info {
                     message: "Comparing IPv4 vs IPv6 performance...".to_string(),
@@ -282,6 +286,7 @@ impl TestEngine {
                 match traceroute::run_traceroute(
                     &hostname,
                     self.cfg.traceroute_max_hops,
+                    self.cfg.ip_version,
                     &event_tx,
                     self.cfg.resolved_bind_ip,
                     self.cfg.interface.as_deref(),

--- a/src/engine/network_bind.rs
+++ b/src/engine/network_bind.rs
@@ -1,49 +1,78 @@
+use crate::model::IpVersionFilter;
 use anyhow::{Context, Result};
 use reqwest::ClientBuilder;
 use std::net::{IpAddr, SocketAddr};
 
-/// Get the IP address of a network interface using the `if-addrs` crate
-pub fn get_interface_ip(interface: &str) -> Result<IpAddr> {
+/// Get the IP address of a network interface using the `if-addrs` crate.
+///
+/// When `filter` is `V4Only` or `V6Only`, only addresses of that family are
+/// considered. With `Auto`, IPv4 is preferred and IPv6 is used as a fallback.
+pub fn get_interface_ip(interface: &str, filter: IpVersionFilter) -> Result<IpAddr> {
     use if_addrs::get_if_addrs;
 
     let addrs = get_if_addrs().context("Failed to enumerate network interfaces")?;
 
-    // Prefer IPv4 addresses
-    for addr in &addrs {
-        if addr.name == interface {
-            if let if_addrs::IfAddr::V4(v4) = &addr.addr {
-                return Ok(IpAddr::V4(v4.ip));
+    let want_v4 = matches!(filter, IpVersionFilter::Auto | IpVersionFilter::V4Only);
+    let want_v6 = matches!(filter, IpVersionFilter::Auto | IpVersionFilter::V6Only);
+
+    if want_v4 {
+        for addr in &addrs {
+            if addr.name == interface {
+                if let if_addrs::IfAddr::V4(v4) = &addr.addr {
+                    return Ok(IpAddr::V4(v4.ip));
+                }
             }
         }
     }
 
-    // Fallback to IPv6 if no IPv4 found
-    for addr in &addrs {
-        if addr.name == interface {
-            if let if_addrs::IfAddr::V6(v6) = &addr.addr {
-                return Ok(IpAddr::V6(v6.ip));
+    if want_v6 {
+        for addr in &addrs {
+            if addr.name == interface {
+                if let if_addrs::IfAddr::V6(v6) = &addr.addr {
+                    return Ok(IpAddr::V6(v6.ip));
+                }
             }
         }
     }
 
-    Err(anyhow::anyhow!(
-        "Interface {} not found or has no IP address assigned",
-        interface
-    ))
+    match filter {
+        IpVersionFilter::Auto => Err(anyhow::anyhow!(
+            "Interface {} not found or has no IP address assigned",
+            interface
+        )),
+        _ => Err(anyhow::anyhow!(
+            "Interface {} has no {} address assigned",
+            interface,
+            filter.label()
+        )),
+    }
 }
 
-/// Resolve binding address from interface name or source IP
+/// Resolve binding address from interface name or source IP.
+///
+/// `filter` enforces that the resulting bind address matches the requested
+/// IP version: `--source` IPs of the wrong family are rejected, and interface
+/// lookup picks an address of the matching family.
 pub fn resolve_bind_address(
     interface: Option<&String>,
     source_ip: Option<&String>,
+    filter: IpVersionFilter,
 ) -> Result<Option<SocketAddr>> {
     if let Some(ip_str) = source_ip {
         let ip: IpAddr = ip_str.parse().context("Invalid source IP address format")?;
+        if !filter.allows_ip(ip) {
+            return Err(anyhow::anyhow!(
+                "--source {} is not an {} address (conflicts with --{}-only)",
+                ip,
+                filter.label(),
+                filter.label().to_lowercase()
+            ));
+        }
         return Ok(Some(SocketAddr::new(ip, 0)));
     }
 
     if let Some(iface) = interface {
-        let ip = get_interface_ip(iface)
+        let ip = get_interface_ip(iface, filter)
             .with_context(|| format!("Failed to get IP for interface {}", iface))?;
         return Ok(Some(SocketAddr::new(ip, 0)));
     }
@@ -81,6 +110,7 @@ pub fn get_interface_for_ip(ip_str: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::IpVersionFilter;
 
     #[test]
     fn test_get_interface_for_ip_loopback() {
@@ -104,34 +134,34 @@ mod tests {
 
     #[test]
     fn test_get_interface_ip_loopback() {
-        let ip = get_interface_ip("lo").unwrap();
+        let ip = get_interface_ip("lo", IpVersionFilter::Auto).unwrap();
         assert_eq!(ip, "127.0.0.1".parse::<IpAddr>().unwrap());
     }
 
     #[test]
     fn test_get_interface_ip_nonexistent() {
-        let result = get_interface_ip("nonexistent_iface_xyz");
+        let result = get_interface_ip("nonexistent_iface_xyz", IpVersionFilter::Auto);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_roundtrip_interface_to_ip_and_back() {
         // Get the IP for loopback, then reverse-lookup should return "lo"
-        let ip = get_interface_ip("lo").unwrap();
+        let ip = get_interface_ip("lo", IpVersionFilter::Auto).unwrap();
         let iface = get_interface_for_ip(&ip.to_string());
         assert_eq!(iface, Some("lo".to_string()));
     }
 
     #[test]
     fn test_resolve_bind_address_none() {
-        let result = resolve_bind_address(None, None).unwrap();
+        let result = resolve_bind_address(None, None, IpVersionFilter::Auto).unwrap();
         assert!(result.is_none());
     }
 
     #[test]
     fn test_resolve_bind_address_source_ip() {
         let source = "127.0.0.1".to_string();
-        let result = resolve_bind_address(None, Some(&source)).unwrap();
+        let result = resolve_bind_address(None, Some(&source), IpVersionFilter::Auto).unwrap();
         let addr = result.unwrap();
         assert_eq!(addr.ip(), "127.0.0.1".parse::<IpAddr>().unwrap());
     }
@@ -139,14 +169,26 @@ mod tests {
     #[test]
     fn test_resolve_bind_address_invalid_source() {
         let source = "not-an-ip".to_string();
-        let result = resolve_bind_address(None, Some(&source));
+        let result = resolve_bind_address(None, Some(&source), IpVersionFilter::Auto);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_bind_address_source_family_mismatch() {
+        // --source IPv4 with --ipv6-only is contradictory
+        let source = "127.0.0.1".to_string();
+        let result = resolve_bind_address(None, Some(&source), IpVersionFilter::V6Only);
+        assert!(result.is_err());
+
+        let source = "::1".to_string();
+        let result = resolve_bind_address(None, Some(&source), IpVersionFilter::V4Only);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_resolve_bind_address_interface() {
         let iface = "lo".to_string();
-        let result = resolve_bind_address(Some(&iface), None).unwrap();
+        let result = resolve_bind_address(Some(&iface), None, IpVersionFilter::Auto).unwrap();
         let addr = result.unwrap();
         assert_eq!(addr.ip(), "127.0.0.1".parse::<IpAddr>().unwrap());
     }
@@ -156,7 +198,8 @@ mod tests {
         // When both are provided, source_ip wins
         let iface = "lo".to_string();
         let source = "192.168.1.1".to_string();
-        let result = resolve_bind_address(Some(&iface), Some(&source)).unwrap();
+        let result =
+            resolve_bind_address(Some(&iface), Some(&source), IpVersionFilter::Auto).unwrap();
         let addr = result.unwrap();
         assert_eq!(addr.ip(), "192.168.1.1".parse::<IpAddr>().unwrap());
     }

--- a/src/engine/tls.rs
+++ b/src/engine/tls.rs
@@ -1,6 +1,6 @@
 //! TLS handshake time measurement module
 
-use crate::model::TlsSummary;
+use crate::model::{IpVersionFilter, TlsSummary};
 use anyhow::{anyhow, Context, Result};
 use rustls::pki_types::ServerName;
 use std::net::{IpAddr, SocketAddr};
@@ -39,6 +39,7 @@ pub async fn measure_tls_handshake(
     port: u16,
     cert_path: Option<&std::path::Path>,
     bind_ip: Option<IpAddr>,
+    filter: IpVersionFilter,
 ) -> Result<TlsSummary> {
     // Ensure the crypto provider is installed
     ensure_crypto_provider();
@@ -68,7 +69,9 @@ pub async fn measure_tls_handshake(
     let connector = TlsConnector::from(Arc::new(config));
 
     // Resolve and connect, trying each address until one succeeds.
-    let tcp_stream = connect_tcp(hostname, port, bind_ip).await?;
+    // Candidates are filtered by both the IP-version filter (--ipv4-only / --ipv6-only)
+    // and the bind IP family so the kernel can actually reach them.
+    let tcp_stream = connect_tcp(hostname, port, bind_ip, filter).await?;
 
     // Parse server name for TLS
     let server_name: ServerName<'static> = hostname
@@ -108,6 +111,7 @@ async fn connect_tcp(
     hostname: &str,
     port: u16,
     bind_ip: Option<IpAddr>,
+    filter: IpVersionFilter,
 ) -> Result<tokio::net::TcpStream> {
     let lookup_target = format!("{}:{}", hostname, port);
     let resolved: Vec<SocketAddr> = lookup_host(&lookup_target)
@@ -119,16 +123,21 @@ async fn connect_tcp(
         return Err(anyhow!("DNS returned no addresses for {}", hostname));
     }
 
-    // Filter by bind family if set; otherwise try all.
-    let candidates: Vec<SocketAddr> = match bind_ip {
-        Some(IpAddr::V4(_)) => resolved.iter().copied().filter(|a| a.is_ipv4()).collect(),
-        Some(IpAddr::V6(_)) => resolved.iter().copied().filter(|a| a.is_ipv6()).collect(),
-        None => resolved.clone(),
-    };
+    // Filter by IP-version selection first, then by bind family if set.
+    let candidates: Vec<SocketAddr> = resolved
+        .iter()
+        .copied()
+        .filter(|a| filter.allows_socket(*a))
+        .filter(|a| match bind_ip {
+            Some(IpAddr::V4(_)) => a.is_ipv4(),
+            Some(IpAddr::V6(_)) => a.is_ipv6(),
+            None => true,
+        })
+        .collect();
 
     if candidates.is_empty() {
         return Err(anyhow!(
-            "no resolved address for {} matches the bind IP family",
+            "no resolved address for {} matches the requested IP family / bind IP",
             hostname
         ));
     }

--- a/src/engine/traceroute.rs
+++ b/src/engine/traceroute.rs
@@ -4,7 +4,7 @@
 //! Uses raw ICMP sockets when available (requires CAP_NET_RAW or root),
 //! with fallback to system traceroute command.
 
-use crate::model::{TestEvent, TracerouteHop, TracerouteSummary};
+use crate::model::{IpVersionFilter, TestEvent, TracerouteHop, TracerouteSummary};
 use anyhow::{Context, Result};
 use pnet_packet::icmp::IcmpTypes;
 use socket2::{Domain, Protocol, Socket, Type};
@@ -30,12 +30,14 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 pub async fn run_traceroute(
     destination: &str,
     max_hops: u8,
+    filter: IpVersionFilter,
     event_tx: &mpsc::Sender<TestEvent>,
     bind_ip: Option<IpAddr>,
     interface: Option<&str>,
 ) -> Result<TracerouteSummary> {
-    // Resolve destination to IP, preferring the bind IP's family when set.
-    let ip = resolve_destination(destination, bind_ip)?;
+    // Resolve destination to IP, restricted to the requested IP-version filter
+    // and (when set) the bind IP's family.
+    let ip = resolve_destination(destination, filter, bind_ip)?;
 
     // Try raw ICMP first
     match run_icmp_traceroute(&ip, max_hops, event_tx, bind_ip, interface).await {
@@ -54,24 +56,43 @@ pub async fn run_traceroute(
     run_system_traceroute(destination, &ip, max_hops, event_tx, bind_ip, interface).await
 }
 
-/// Resolve destination hostname to IP address. When `bind_ip` is set, prefer
-/// a resolved address of the same family; if none exists, error rather than
-/// returning an address the bound socket can't reach.
-fn resolve_destination(destination: &str, bind_ip: Option<IpAddr>) -> Result<IpAddr> {
+/// Resolve destination hostname to IP address. The `filter` restricts the
+/// result to a single family when `--ipv4-only` / `--ipv6-only` is set, and
+/// `bind_ip` further constrains the resolved address to the bind IP's family.
+fn resolve_destination(
+    destination: &str,
+    filter: IpVersionFilter,
+    bind_ip: Option<IpAddr>,
+) -> Result<IpAddr> {
     // Try to parse as IP first
     if let Ok(ip) = destination.parse::<IpAddr>() {
+        if !filter.allows_ip(ip) {
+            return Err(anyhow::anyhow!(
+                "{} is not an {} address",
+                ip,
+                filter.label()
+            ));
+        }
         return Ok(ip);
     }
 
-    // Try DNS resolution
+    // DNS resolution, restricted to the requested IP-version filter.
     let addrs: Vec<IpAddr> = format!("{}:0", destination)
         .to_socket_addrs()
         .with_context(|| format!("Failed to resolve {}", destination))?
         .map(|a| a.ip())
+        .filter(|ip| filter.allows_ip(*ip))
         .collect();
 
     if addrs.is_empty() {
-        return Err(anyhow::anyhow!("No addresses found for {}", destination));
+        return Err(match filter {
+            IpVersionFilter::Auto => anyhow::anyhow!("No addresses found for {}", destination),
+            _ => anyhow::anyhow!(
+                "No {} addresses found for {}",
+                filter.label(),
+                destination
+            ),
+        });
     }
 
     match bind_ip {
@@ -314,30 +335,64 @@ async fn run_system_traceroute(
     bind_ip: Option<IpAddr>,
     interface: Option<&str>,
 ) -> Result<TracerouteSummary> {
-    // Clone strings to avoid lifetime issues with spawn_blocking
-    let dest = destination.to_string();
+    // Target the already-resolved IP literal rather than the hostname: its
+    // family is exactly what resolve_destination selected (honoring
+    // --ipv4-only / --ipv6-only and the bind IP), so the external command can't
+    // re-resolve to a different family. Cloned for spawn_blocking.
     let dest_ip_str = destination_ip.to_string();
+    let is_v6 = destination_ip.is_ipv6();
 
-    // Determine which command to use based on OS.
-    // Note: -n / -d intentionally NOT passed so the OS resolves hostnames.
-    // Source IP and interface flags differ per platform:
-    //   - tracert (Windows):     -S <srcaddr> only, no interface flag.
-    //   - traceroute (Linux/BSD): -i <interface> and -s <source>.
+    // Pick the command per platform. The family comes from the resolved
+    // address, so Auto, --ipv4-only, and --ipv6-only all work.
+    // Note: -n / -d intentionally NOT passed so hop IPs still resolve to names.
+    //   - tracert (Windows):  one binary; -4 / -6 forces family, -S <src>.
+    //   - traceroute (Linux): one binary; -4 / -6 forces family.
+    //   - macOS/BSD:          plain `traceroute` is IPv4-only and rejects -6;
+    //                         IPv6 needs the separate `traceroute6` binary.
+    //                         Both accept the same -m / -q / -i / -s options.
     let (cmd, args): (&'static str, Vec<String>) = if cfg!(target_os = "windows") {
-        let mut args = vec!["-h".to_string(), max_hops.to_string()];
+        let mut args = vec![
+            if is_v6 { "-6" } else { "-4" }.to_string(),
+            "-h".to_string(),
+            max_hops.to_string(),
+        ];
         if let Some(ip) = bind_ip {
             args.push("-S".to_string());
             args.push(ip.to_string());
         }
-        args.push(dest.clone());
+        args.push(dest_ip_str.clone());
         ("tracert", args)
     } else {
-        let mut args = vec![
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly"
+        ))]
+        let (cmd, family_flag): (&'static str, Option<&'static str>) =
+            (if is_v6 { "traceroute6" } else { "traceroute" }, None);
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly"
+        )))]
+        let (cmd, family_flag): (&'static str, Option<&'static str>) =
+            ("traceroute", Some(if is_v6 { "-6" } else { "-4" }));
+
+        let mut args = Vec::new();
+        if let Some(flag) = family_flag {
+            args.push(flag.to_string());
+        }
+        args.extend([
             "-m".to_string(),
             max_hops.to_string(),
             "-q".to_string(),
             "3".to_string(),
-        ];
+        ]);
         if let Some(iface) = interface {
             args.push("-i".to_string());
             args.push(iface.to_string());
@@ -346,8 +401,8 @@ async fn run_system_traceroute(
             args.push("-s".to_string());
             args.push(ip.to_string());
         }
-        args.push(dest.clone());
-        ("traceroute", args)
+        args.push(dest_ip_str.clone());
+        (cmd, args)
     };
 
     let output = tokio::task::spawn_blocking(move || Command::new(cmd).args(&args).output())

--- a/src/engine/turn_udp.rs
+++ b/src/engine/turn_udp.rs
@@ -158,18 +158,23 @@ pub async fn run_udp_like_loss_probe(
         return Err(anyhow!("dns returned no addresses for {}", host));
     }
 
-    // When a bind IP is set, only target addresses of the matching family are
-    // reachable: a UDP socket bound to a v4 source can't connect() to a v6
-    // peer (EAFNOSUPPORT) and vice versa.
-    let candidates: Vec<SocketAddr> = match cfg.resolved_bind_ip {
-        Some(IpAddr::V4(_)) => resolved.iter().copied().filter(|a| a.is_ipv4()).collect(),
-        Some(IpAddr::V6(_)) => resolved.iter().copied().filter(|a| a.is_ipv6()).collect(),
-        None => resolved,
-    };
+    // Apply --ipv4-only / --ipv6-only first, then narrow by bind IP family.
+    // A UDP socket bound to a v4 source can't connect() to a v6 peer
+    // (EAFNOSUPPORT) and vice versa, so both filters must match.
+    let candidates: Vec<SocketAddr> = resolved
+        .iter()
+        .copied()
+        .filter(|a| cfg.ip_version.allows_socket(*a))
+        .filter(|a| match cfg.resolved_bind_ip {
+            Some(IpAddr::V4(_)) => a.is_ipv4(),
+            Some(IpAddr::V6(_)) => a.is_ipv6(),
+            None => true,
+        })
+        .collect();
 
     if candidates.is_empty() {
         return Err(anyhow!(
-            "no resolved address for {} matches the bind IP family",
+            "no resolved address for {} matches the requested IP family / bind IP",
             host
         ));
     }
@@ -290,8 +295,11 @@ async fn bind_and_connect_udp(
     candidates: &[SocketAddr],
     cfg: &RunConfig,
 ) -> Result<(UdpSocket, SocketAddr)> {
-    let bind_addr =
-        network_bind::resolve_bind_address(cfg.interface.as_ref(), cfg.source_ip.as_ref())?;
+    let bind_addr = network_bind::resolve_bind_address(
+        cfg.interface.as_ref(),
+        cfg.source_ip.as_ref(),
+        cfg.ip_version,
+    )?;
 
     let mut last_err: Option<anyhow::Error> = None;
     for &addr in candidates {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,63 @@
 use serde::{Deserialize, Serialize};
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum IpVersionFilter {
+    #[default]
+    Auto,
+    V4Only,
+    V6Only,
+}
+
+impl IpVersionFilter {
+    pub fn allows_ip(&self, addr: IpAddr) -> bool {
+        match self {
+            IpVersionFilter::Auto => true,
+            IpVersionFilter::V4Only => addr.is_ipv4(),
+            IpVersionFilter::V6Only => addr.is_ipv6(),
+        }
+    }
+
+    pub fn allows_socket(&self, addr: SocketAddr) -> bool {
+        self.allows_ip(addr.ip())
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            IpVersionFilter::Auto => "auto",
+            IpVersionFilter::V4Only => "IPv4",
+            IpVersionFilter::V6Only => "IPv6",
+        }
+    }
+}
+
+#[cfg(test)]
+mod ip_version_filter_tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn auto_allows_both_families() {
+        let f = IpVersionFilter::Auto;
+        assert!(f.allows_ip(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert!(f.allows_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+    }
+
+    #[test]
+    fn v4_only_rejects_v6() {
+        let f = IpVersionFilter::V4Only;
+        assert!(f.allows_ip(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert!(!f.allows_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+    }
+
+    #[test]
+    fn v6_only_rejects_v4() {
+        let f = IpVersionFilter::V6Only;
+        assert!(!f.allows_ip(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert!(f.allows_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+    }
+}
 
 mod loss_percent_serde {
     use serde::{Deserialize, Deserializer, Serializer};
@@ -52,8 +109,8 @@ pub struct RunConfig {
     pub compare_ip_versions: bool,
     pub traceroute: bool,
     pub traceroute_max_hops: u8,
-    pub ipv4_only: bool,
-    pub ipv6_only: bool,
+    #[serde(default)]
+    pub ip_version: IpVersionFilter,
     pub udp_packets: u64,
 }
 

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -165,6 +165,14 @@ pub fn max_y(points: &[(f64, f64)]) -> f64 {
     points.iter().map(|(_, y)| *y).fold(0.0, |a, b| a.max(b))
 }
 
+fn is_ipv4_str(s: &str) -> bool {
+    s.parse::<std::net::Ipv4Addr>().is_ok()
+}
+
+fn is_ipv6_str(s: &str) -> bool {
+    s.parse::<std::net::Ipv6Addr>().is_ok()
+}
+
 fn udp_split_bar(sent: u64, received: u64, width: usize) -> Line<'static> {
     let safe_sent = sent.max(1);
     let safe_received = received.min(safe_sent);
@@ -777,13 +785,28 @@ pub fn draw_dashboard(area: Rect, f: &mut Frame, state: &UiState) {
     }
     network_lines.push(Line::from(your_network));
 
+    // Fall back to state.ip (the connection IP from /cdn-cgi/trace) only when
+    // its family matches the row — otherwise --ipv6-only would surface an IPv6
+    // address in the IPv4 row.
     let external_ipv4_display = if hide {
         REDACTED_PLACEHOLDER.to_string()
     } else {
         state
             .external_ipv4
             .as_deref()
-            .unwrap_or(state.ip.as_deref().unwrap_or("-"))
+            .or_else(|| state.ip.as_deref().filter(|s| is_ipv4_str(s)))
+            .unwrap_or("-")
+            .to_string()
+    };
+
+    let external_ipv6_display = if hide {
+        REDACTED_PLACEHOLDER.to_string()
+    } else {
+        state
+            .external_ipv6
+            .as_deref()
+            .or_else(|| state.ip.as_deref().filter(|s| is_ipv6_str(s)))
+            .unwrap_or("-")
             .to_string()
     };
 
@@ -794,10 +817,7 @@ pub fn draw_dashboard(area: Rect, f: &mut Frame, state: &UiState) {
         ]),
         Line::from(vec![
             Span::styled("External IPv6: ", Style::default().fg(Color::Gray)),
-            Span::styled(
-                show_or_redact(state.external_ipv6.as_deref(), hide).to_string(),
-                Style::default().fg(Color::Cyan),
-            ),
+            Span::styled(external_ipv6_display, Style::default().fg(Color::Cyan)),
         ]),
     ]);
 


### PR DESCRIPTION
The `--ipv4-only` and `--ipv6-only` flags appeared to be defined as options but did not appear to be functional. This PR attempts to wire these up in as comprehensive of a way as possible.

They now constrain DNS resolution and bind-address selection in the cloudflare client, TLS handshake probe, traceroute, UDP loss probe, and external-IP fetch. clap rejects combinations of --ipv4-only/--ipv6-only with each other and with --compare-ip-versions, and a --source IP whose family conflicts with the selected version is rejected.

This is admittedly agent-coded but appears clean and tests correctly.