### PR TITLE
Bind to a network interface with dual-stack support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,12 +77,19 @@ pub struct Cli {
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub auto_save: bool,
 
-    /// Bind to a specific network interface (e.g., ens18, eth0)
+    /// Bind all test traffic to a specific network interface (e.g. ens18, eth0).
+    /// On Linux/macOS this uses device binding (SO_BINDTODEVICE / IP_BOUND_IF),
+    /// so both IPv4 and IPv6 destinations stay reachable. On platforms without
+    /// device binding (Windows, the BSDs) it instead binds one of the
+    /// interface's source IPs — a single address family, preferring IPv6; pass
+    /// -4 / -6 to pick the family.
     #[arg(long)]
     pub interface: Option<String>,
 
-    /// Bind to a specific source IP address (e.g., 192.168.10.0)
-    #[arg(long)]
+    /// Bind all test traffic to a specific source IP address (e.g. 192.168.10.5).
+    /// Constrains the test to that address's family (IPv4 or IPv6). Mutually
+    /// exclusive with --interface.
+    #[arg(long, conflicts_with = "interface")]
     pub source: Option<String>,
 
     /// Route traffic through a proxy (HTTP, HTTPS, or SOCKS5)
@@ -189,24 +196,46 @@ pub fn build_config(args: &Cli) -> Result<RunConfig> {
     // DNS and TLS run by default unless --skip-diagnostics is set
     let skip = args.skip_diagnostics;
 
-    // Resolve bind address once from --interface or --source
-    let resolved_bind_ip = network_bind::resolve_bind_address(
-        args.interface.as_ref(),
-        args.source.as_ref(),
-    )?
-    .map(|addr| addr.ip());
+    // The requested IP-version restriction (from --ipv4-only / --ipv6-only),
+    // validated up front. `None` = unrestricted.
+    let family = network_bind::resolve_ip_family(args.ipv4_only, args.ipv6_only, None)?;
 
-    if let Some(ip) = resolved_bind_ip {
-        if let Some(ref iface) = args.interface {
-            eprintln!("Binding HTTP connections to interface {} (IP: {})", iface, ip);
-        } else {
-            eprintln!("Binding HTTP connections to source IP: {}", ip);
+    // Bind resolution (--source and --interface are mutually exclusive at the
+    // CLI). --source pins a specific local IP. --interface uses device binding
+    // (SO_BINDTODEVICE / IP_BOUND_IF) where available, which keeps the run
+    // dual-stack with no pinned IP; on platforms without it we instead pin the
+    // interface's own source IP for the requested family (preferring IPv6 when
+    // unrestricted). Either way the result is a single `resolved_bind_ip` (or
+    // None for device binding) consumed by the existing source-IP/family
+    // machinery. The user-facing notice is emitted by the caller (see
+    // `bind_notice`), NOT here: build_config runs inside the TUI's alternate
+    // screen, where stray stderr writes corrupt the display.
+    let resolved_bind_ip = if let Some(src) = args.source.as_deref() {
+        Some(src.parse().context("Invalid source IP address format")?)
+    } else if let Some(iface) = args.interface.as_deref() {
+        if !network_bind::interface_exists(iface) {
+            return Err(anyhow::anyhow!(
+                "Interface '{}' not found or has no addresses",
+                iface
+            ));
         }
-    }
+        if network_bind::device_binding_supported() {
+            None
+        } else {
+            Some(network_bind::interface_source_ip(iface, family).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Interface '{}' has no usable {} address",
+                    iface,
+                    family.map(|f| f.label()).unwrap_or("IP")
+                )
+            })?)
+        }
+    } else {
+        None
+    };
 
-    // Validate the IP-version selection up front so contradictions (both
-    // --ipv4-only and --ipv6-only, or a flag that disagrees with the bound
-    // source IP's family) fail before the test starts rather than mid-run.
+    // Re-validate now that --source's family is known (a v4 source with
+    // --ipv6-only, etc.). For --interface we already selected a matching family.
     network_bind::resolve_ip_family(args.ipv4_only, args.ipv6_only, resolved_bind_ip)?;
 
     Ok(RunConfig {
@@ -240,10 +269,36 @@ pub fn build_config(args: &Cli) -> Result<RunConfig> {
     })
 }
 
+/// One-line summary of the active interface/source binding, or `None` when
+/// neither was given. Emitted on stderr in text/json modes (the TUI shows the
+/// interface in its Network Information panel instead).
+pub fn bind_notice(cfg: &RunConfig) -> Option<String> {
+    // --source and --interface are mutually exclusive, so at most one applies.
+    match (cfg.interface.as_deref(), cfg.resolved_bind_ip) {
+        // Device binding: no pinned IP, the OS sources per family.
+        (Some(iface), None) => Some(format!(
+            "Binding sockets to interface {} (device binding; dual-stack preserved)",
+            iface
+        )),
+        // No device binding: the interface was resolved to a single source IP.
+        (Some(iface), Some(ip)) => Some(format!(
+            "Binding sockets to interface {} via source IP {} (single address family)",
+            iface, ip
+        )),
+        (None, Some(ip)) => Some(format!("Binding sockets to source IP {}", ip)),
+        (None, None) => None,
+    }
+}
+
 /// Common function to run the test engine and process results.
 /// `silent` controls whether JSON is printed and whether save errors propagate.
 async fn run_test_engine(args: Cli, silent: bool) -> Result<()> {
     let cfg = build_config(&args)?;
+    if !silent {
+        if let Some(msg) = bind_notice(&cfg) {
+            eprintln!("{}", msg);
+        }
+    }
     let network_info = crate::network::gather_network_info(&args);
 
     let (evt_tx, mut evt_rx) = mpsc::channel::<TestEvent>(2048);
@@ -308,6 +363,9 @@ async fn run_test_engine(args: Cli, silent: bool) -> Result<()> {
 
 async fn run_text(args: Cli) -> Result<()> {
     let cfg = build_config(&args)?;
+    if let Some(msg) = bind_notice(&cfg) {
+        eprintln!("{}", msg);
+    }
     let (evt_tx, mut evt_rx) = mpsc::channel::<TestEvent>(2048);
     let (_, ctrl_rx) = mpsc::channel::<EngineControl>(16);
 

--- a/src/engine/cloudflare.rs
+++ b/src/engine/cloudflare.rs
@@ -39,7 +39,7 @@ impl CloudflareClient {
             .connect_timeout(crate::constants::HTTP_CONNECT_TIMEOUT)
             .tcp_keepalive(Duration::from_secs(15));
 
-        builder = network_bind::apply_local_address(builder, cfg.resolved_bind_ip);
+        builder = network_bind::apply_bind(builder, cfg.interface.as_deref(), cfg.resolved_bind_ip);
 
         // Pin DNS resolution to the requested family for --ipv4-only /
         // --ipv6-only. A proxy resolves the target itself, so the override

--- a/src/engine/dns.rs
+++ b/src/engine/dns.rs
@@ -227,6 +227,7 @@ pub fn extract_hostname(url: &str) -> Option<String> {
 /// issued and left to time out.
 pub async fn fetch_external_ips(
     base_url: &str,
+    interface: Option<&str>,
     bind_ip: Option<std::net::IpAddr>,
     cert_path: Option<&std::path::Path>,
     family: Option<super::network_bind::IpFamily>,
@@ -247,14 +248,14 @@ pub async fn fetch_external_ips(
     let (ipv4, ipv6) = tokio::join!(
         async {
             if want_v4 {
-                fetch_external_ip_version(&url, &hostname, IpVersion::V4, bind_ip, cert_path).await
+                fetch_external_ip_version(&url, &hostname, IpVersion::V4, interface, bind_ip, cert_path).await
             } else {
                 None
             }
         },
         async {
             if want_v6 {
-                fetch_external_ip_version(&url, &hostname, IpVersion::V6, bind_ip, cert_path).await
+                fetch_external_ip_version(&url, &hostname, IpVersion::V6, interface, bind_ip, cert_path).await
             } else {
                 None
             }
@@ -274,6 +275,7 @@ async fn fetch_external_ip_version(
     url: &str,
     hostname: &str,
     version: IpVersion,
+    interface: Option<&str>,
     bind_ip: Option<std::net::IpAddr>,
     cert_path: Option<&std::path::Path>,
 ) -> Option<String> {
@@ -301,7 +303,7 @@ async fn fetch_external_ip_version(
     if let Some(path) = cert_path {
         builder = builder.add_root_certificate(super::cert::load_reqwest_certificate(path).ok()?);
     }
-    let client = network_bind::apply_local_address(builder, bind_ip)
+    let client = network_bind::apply_bind(builder, interface, bind_ip)
         .build()
         .ok()?;
 

--- a/src/engine/ip_comparison.rs
+++ b/src/engine/ip_comparison.rs
@@ -20,6 +20,7 @@ const TEST_DURATION: Duration = Duration::from_secs(3);
 pub async fn compare_ip_versions(
     base_url: &str,
     user_agent: &str,
+    interface: Option<&str>,
     bind_ip: Option<IpAddr>,
     cert_path: Option<&std::path::Path>,
     family: Option<IpFamily>,
@@ -58,7 +59,7 @@ pub async fn compare_ip_versions(
     let ipv4_result = Some(if !test_v4 {
         skipped_result(family)
     } else if let Some(ip) = ipv4_addr {
-        test_ip_version(base_url, hostname, port, ip, user_agent, bind_ip, cert_path).await
+        test_ip_version(base_url, hostname, port, ip, user_agent, interface, bind_ip, cert_path).await
     } else {
         unavailable_result("No IPv4 address resolved")
     });
@@ -67,7 +68,7 @@ pub async fn compare_ip_versions(
     let ipv6_result = Some(if !test_v6 {
         skipped_result(family)
     } else if let Some(ip) = ipv6_addr {
-        test_ip_version(base_url, hostname, port, ip, user_agent, bind_ip, cert_path).await
+        test_ip_version(base_url, hostname, port, ip, user_agent, interface, bind_ip, cert_path).await
     } else {
         unavailable_result("No IPv6 address resolved")
     });
@@ -99,12 +100,14 @@ fn skipped_result(family: Option<IpFamily>) -> IpVersionResult {
 }
 
 /// Test a specific IP version by forcing requests to that IP.
+#[allow(clippy::too_many_arguments)]
 async fn test_ip_version(
     base_url: &str,
     hostname: &str,
     port: u16,
     ip: IpAddr,
     user_agent: &str,
+    interface: Option<&str>,
     bind_ip: Option<IpAddr>,
     cert_path: Option<&std::path::Path>,
 ) -> IpVersionResult {
@@ -132,7 +135,7 @@ async fn test_ip_version(
             }
         }
     }
-    let client = match network_bind::apply_local_address(builder, bind_ip).build() {
+    let client = match network_bind::apply_bind(builder, interface, bind_ip).build() {
         Ok(c) => c,
         Err(e) => {
             return IpVersionResult {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -197,6 +197,7 @@ impl TestEngine {
                     &hostname,
                     port,
                     self.cfg.certificate_path.as_deref(),
+                    self.cfg.interface.as_deref(),
                     self.cfg.resolved_bind_ip,
                     family,
                 )
@@ -227,6 +228,7 @@ impl TestEngine {
         if self.cfg.measure_dns {
             let (v4, v6) = dns::fetch_external_ips(
                 &self.cfg.base_url,
+                self.cfg.interface.as_deref(),
                 self.cfg.resolved_bind_ip,
                 self.cfg.certificate_path.as_deref(),
                 family,
@@ -252,6 +254,7 @@ impl TestEngine {
             match ip_comparison::compare_ip_versions(
                 &self.cfg.base_url,
                 &self.cfg.user_agent,
+                self.cfg.interface.as_deref(),
                 self.cfg.resolved_bind_ip,
                 self.cfg.certificate_path.as_deref(),
                 family,

--- a/src/engine/network_bind.rs
+++ b/src/engine/network_bind.rs
@@ -141,11 +141,23 @@ pub fn interface_source_ip(interface: &str, family: Option<IpFamily>) -> Option<
             }
         }
     }
-    let v6 = global_v6.or(link_local_v6);
+    select_source_ip(family, v4, global_v6, link_local_v6)
+}
+
+/// Preference order for `interface_source_ip`, split out so it can be unit-tested
+/// without a real interface. With no family restriction we prefer a routable
+/// global IPv6, then IPv4; a link-local IPv6 is only ever a last resort, since a
+/// bare `fe80::` source (no scope id) can't reach a global destination.
+fn select_source_ip(
+    family: Option<IpFamily>,
+    v4: Option<IpAddr>,
+    global_v6: Option<IpAddr>,
+    link_local_v6: Option<IpAddr>,
+) -> Option<IpAddr> {
     match family {
         Some(IpFamily::V4) => v4,
-        Some(IpFamily::V6) => v6,
-        None => v6.or(v4),
+        Some(IpFamily::V6) => global_v6.or(link_local_v6),
+        None => global_v6.or(v4).or(link_local_v6),
     }
 }
 
@@ -332,6 +344,39 @@ mod tests {
     #[test]
     fn test_interface_source_ip_nonexistent() {
         assert!(interface_source_ip("nonexistent_iface_xyz", None).is_none());
+    }
+
+    #[test]
+    fn test_select_source_ip_prefers_routable_over_link_local() {
+        let v4: IpAddr = "192.168.1.50".parse().unwrap();
+        let global_v6: IpAddr = "2001:db8::1".parse().unwrap();
+        let link_local: IpAddr = "fe80::1".parse().unwrap();
+
+        // Unrestricted: a routable global IPv6 wins when present.
+        assert_eq!(
+            select_source_ip(None, Some(v4), Some(global_v6), Some(link_local)),
+            Some(global_v6)
+        );
+        // Unrestricted with only a link-local IPv6: a usable IPv4 must win over
+        // the unroutable fe80 source (the regression this guards against).
+        assert_eq!(
+            select_source_ip(None, Some(v4), None, Some(link_local)),
+            Some(v4)
+        );
+        // Link-local is chosen only when nothing routable exists.
+        assert_eq!(
+            select_source_ip(None, None, None, Some(link_local)),
+            Some(link_local)
+        );
+        // Explicit families honor the request.
+        assert_eq!(
+            select_source_ip(Some(IpFamily::V4), Some(v4), Some(global_v6), None),
+            Some(v4)
+        );
+        assert_eq!(
+            select_source_ip(Some(IpFamily::V6), Some(v4), Some(global_v6), Some(link_local)),
+            Some(global_v6)
+        );
     }
 
     #[test]

--- a/src/engine/network_bind.rs
+++ b/src/engine/network_bind.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use reqwest::ClientBuilder;
+use std::io;
 use std::net::{IpAddr, SocketAddr};
 
 /// Outbound IP protocol-version restriction for a run.
@@ -94,54 +95,6 @@ pub async fn resolve_addrs_for_family(
     Ok(addrs)
 }
 
-/// Get the IP address of a network interface using the `if-addrs` crate
-pub fn get_interface_ip(interface: &str) -> Result<IpAddr> {
-    use if_addrs::get_if_addrs;
-
-    let addrs = get_if_addrs().context("Failed to enumerate network interfaces")?;
-
-    // Prefer IPv4 addresses
-    for addr in &addrs {
-        if addr.name == interface {
-            if let if_addrs::IfAddr::V4(v4) = &addr.addr {
-                return Ok(IpAddr::V4(v4.ip));
-            }
-        }
-    }
-
-    // Fallback to IPv6 if no IPv4 found
-    for addr in &addrs {
-        if addr.name == interface {
-            if let if_addrs::IfAddr::V6(v6) = &addr.addr {
-                return Ok(IpAddr::V6(v6.ip));
-            }
-        }
-    }
-
-    Err(anyhow::anyhow!(
-        "Interface {} not found or has no IP address assigned",
-        interface
-    ))
-}
-
-/// Resolve binding address from interface name or source IP
-pub fn resolve_bind_address(
-    interface: Option<&String>,
-    source_ip: Option<&String>,
-) -> Result<Option<SocketAddr>> {
-    if let Some(ip_str) = source_ip {
-        let ip: IpAddr = ip_str.parse().context("Invalid source IP address format")?;
-        return Ok(Some(SocketAddr::new(ip, 0)));
-    }
-
-    if let Some(iface) = interface {
-        let ip = get_interface_ip(iface)
-            .with_context(|| format!("Failed to get IP for interface {}", iface))?;
-        return Ok(Some(SocketAddr::new(ip, 0)));
-    }
-
-    Ok(None)
-}
 
 /// Apply local address binding to a reqwest client builder.
 /// If `bind_ip` is Some, binds the client to that local address.
@@ -150,6 +103,154 @@ pub fn apply_local_address(builder: ClientBuilder, bind_ip: Option<IpAddr>) -> C
         Some(ip) => builder.local_address(ip),
         None => builder,
     }
+}
+
+/// Whether this platform can bind a socket to an interface *by name* — Linux via
+/// `SO_BINDTODEVICE`, macOS via `IP_BOUND_IF`/`IPV6_BOUND_IF`. On these the OS
+/// selects a source address per family, so `--interface` stays dual-stack.
+/// Everywhere else (Windows, the BSDs) we fall back to binding the interface's
+/// own IP (a single address family).
+pub const fn device_binding_supported() -> bool {
+    cfg!(any(target_os = "linux", target_os = "macos"))
+}
+
+/// The source address to bind for `--interface` on platforms without device
+/// binding, where pinning traffic to an interface means binding one of its
+/// addresses. `family` honors `--ipv4-only`/`--ipv6-only`; with no restriction
+/// it prefers a routable IPv6 (the system's usual preference and faster path),
+/// then IPv4. A link-local IPv6 is only ever a last resort. `None` if the
+/// interface has no address of the required family.
+pub fn interface_source_ip(interface: &str, family: Option<IpFamily>) -> Option<IpAddr> {
+    let addrs = if_addrs::get_if_addrs().ok()?;
+    let mut v4: Option<IpAddr> = None;
+    let mut global_v6: Option<IpAddr> = None;
+    let mut link_local_v6: Option<IpAddr> = None;
+    for a in &addrs {
+        if a.name != interface {
+            continue;
+        }
+        match &a.addr {
+            if_addrs::IfAddr::V4(v4a) => {
+                v4.get_or_insert(IpAddr::V4(v4a.ip));
+            }
+            if_addrs::IfAddr::V6(v6) if crate::network::is_link_local_v6(&v6.ip) => {
+                link_local_v6.get_or_insert(IpAddr::V6(v6.ip));
+            }
+            if_addrs::IfAddr::V6(v6) => {
+                global_v6.get_or_insert(IpAddr::V6(v6.ip));
+            }
+        }
+    }
+    let v6 = global_v6.or(link_local_v6);
+    match family {
+        Some(IpFamily::V4) => v4,
+        Some(IpFamily::V6) => v6,
+        None => v6.or(v4),
+    }
+}
+
+/// Whether a network interface with the given name currently exists.
+pub fn interface_exists(name: &str) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        if std::path::Path::new(&format!("/sys/class/net/{}", name)).exists() {
+            return true;
+        }
+    }
+    if_addrs::get_if_addrs()
+        .map(|addrs| addrs.iter().any(|a| a.name == name))
+        .unwrap_or(false)
+}
+
+/// Apply `--interface` / `--source` binding to a reqwest client builder.
+///
+/// On device-binding platforms `interface` uses `.interface()`, so the OS picks
+/// a source address per family and the run stays dual-stack. `bind_ip` (from
+/// `--source`, or the interface's resolved IP on platforms without device
+/// binding) pins the local address to a single family. The two are mutually
+/// exclusive at the CLI, so at most one applies.
+pub fn apply_bind(
+    builder: ClientBuilder,
+    interface: Option<&str>,
+    bind_ip: Option<IpAddr>,
+) -> ClientBuilder {
+    let builder = apply_local_address(builder, bind_ip);
+
+    // `.interface()` exists only on the device-binding platforms; elsewhere the
+    // interface was already resolved to `bind_ip` above.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    if let Some(iface) = interface {
+        return builder.interface(iface);
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    let _ = interface;
+
+    builder
+}
+
+/// Bind an already-created socket to a network interface by name: Linux uses
+/// `SO_BINDTODEVICE`, macOS uses `IP_BOUND_IF`/`IPV6_BOUND_IF` (chosen by
+/// `is_ipv6`). A no-op on every other platform (where the caller instead binds
+/// the interface's source IP), so it can be called unconditionally.
+#[cfg(target_os = "linux")]
+pub fn bind_socket_to_device<S: std::os::unix::io::AsRawFd>(
+    sock: &S,
+    interface: &str,
+    _is_ipv6: bool,
+) -> io::Result<()> {
+    let cname = std::ffi::CString::new(interface)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid interface name"))?;
+    let ret = unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_BINDTODEVICE,
+            cname.as_ptr() as *const libc::c_void,
+            cname.as_bytes().len() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn bind_socket_to_device<S: std::os::unix::io::AsRawFd>(
+    sock: &S,
+    interface: &str,
+    is_ipv6: bool,
+) -> io::Result<()> {
+    let cname = std::ffi::CString::new(interface)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid interface name"))?;
+    let idx = unsafe { libc::if_nametoindex(cname.as_ptr()) };
+    if idx == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let (level, optname) = if is_ipv6 {
+        (libc::IPPROTO_IPV6, libc::IPV6_BOUND_IF)
+    } else {
+        (libc::IPPROTO_IP, libc::IP_BOUND_IF)
+    };
+    let idx = idx as libc::c_int;
+    let ret = unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            level,
+            optname,
+            &idx as *const libc::c_int as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn bind_socket_to_device<S>(_sock: &S, _interface: &str, _is_ipv6: bool) -> io::Result<()> {
+    Ok(())
 }
 
 /// Reverse-lookup: find the interface name that owns a given IP address.
@@ -182,6 +283,16 @@ mod tests {
     const LOOPBACK_IFACE: &str = "lo0";
 
     #[test]
+    fn test_interface_exists_loopback() {
+        assert!(interface_exists(LOOPBACK_IFACE));
+    }
+
+    #[test]
+    fn test_interface_exists_nonexistent() {
+        assert!(!interface_exists("nonexistent_iface_xyz"));
+    }
+
+    #[test]
     fn test_get_interface_for_ip_loopback() {
         // 127.0.0.1 is bound to the loopback interface ("lo" on Linux, "lo0" on macOS/BSD)
         let iface = get_interface_for_ip("127.0.0.1");
@@ -202,62 +313,25 @@ mod tests {
     }
 
     #[test]
-    fn test_get_interface_ip_loopback() {
-        let ip = get_interface_ip(LOOPBACK_IFACE).unwrap();
-        assert_eq!(ip, "127.0.0.1".parse::<IpAddr>().unwrap());
+    fn test_interface_source_ip_loopback() {
+        // Loopback has both 127.0.0.1 and ::1; ::1 is routable (not link-local).
+        // Unrestricted prefers IPv6; --ipv4-only/--ipv6-only honor the family.
+        let v4: IpAddr = "127.0.0.1".parse().unwrap();
+        let v6: IpAddr = "::1".parse().unwrap();
+        assert_eq!(interface_source_ip(LOOPBACK_IFACE, None), Some(v6));
+        assert_eq!(
+            interface_source_ip(LOOPBACK_IFACE, Some(IpFamily::V6)),
+            Some(v6)
+        );
+        assert_eq!(
+            interface_source_ip(LOOPBACK_IFACE, Some(IpFamily::V4)),
+            Some(v4)
+        );
     }
 
     #[test]
-    fn test_get_interface_ip_nonexistent() {
-        let result = get_interface_ip("nonexistent_iface_xyz");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_roundtrip_interface_to_ip_and_back() {
-        // Get the IP for loopback, then reverse-lookup should return the loopback name
-        let ip = get_interface_ip(LOOPBACK_IFACE).unwrap();
-        let iface = get_interface_for_ip(&ip.to_string());
-        assert_eq!(iface, Some(LOOPBACK_IFACE.to_string()));
-    }
-
-    #[test]
-    fn test_resolve_bind_address_none() {
-        let result = resolve_bind_address(None, None).unwrap();
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_resolve_bind_address_source_ip() {
-        let source = "127.0.0.1".to_string();
-        let result = resolve_bind_address(None, Some(&source)).unwrap();
-        let addr = result.unwrap();
-        assert_eq!(addr.ip(), "127.0.0.1".parse::<IpAddr>().unwrap());
-    }
-
-    #[test]
-    fn test_resolve_bind_address_invalid_source() {
-        let source = "not-an-ip".to_string();
-        let result = resolve_bind_address(None, Some(&source));
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_resolve_bind_address_interface() {
-        let iface = LOOPBACK_IFACE.to_string();
-        let result = resolve_bind_address(Some(&iface), None).unwrap();
-        let addr = result.unwrap();
-        assert_eq!(addr.ip(), "127.0.0.1".parse::<IpAddr>().unwrap());
-    }
-
-    #[test]
-    fn test_resolve_bind_address_source_takes_priority() {
-        // When both are provided, source_ip wins
-        let iface = LOOPBACK_IFACE.to_string();
-        let source = "192.168.1.1".to_string();
-        let result = resolve_bind_address(Some(&iface), Some(&source)).unwrap();
-        let addr = result.unwrap();
-        assert_eq!(addr.ip(), "192.168.1.1".parse::<IpAddr>().unwrap());
+    fn test_interface_source_ip_nonexistent() {
+        assert!(interface_source_ip("nonexistent_iface_xyz", None).is_none());
     }
 
     #[test]

--- a/src/engine/tls.rs
+++ b/src/engine/tls.rs
@@ -40,6 +40,7 @@ pub async fn measure_tls_handshake(
     hostname: &str,
     port: u16,
     cert_path: Option<&std::path::Path>,
+    interface: Option<&str>,
     bind_ip: Option<IpAddr>,
     family: Option<IpFamily>,
 ) -> Result<TlsSummary> {
@@ -71,7 +72,7 @@ pub async fn measure_tls_handshake(
     let connector = TlsConnector::from(Arc::new(config));
 
     // Resolve and connect, trying each address until one succeeds.
-    let tcp_stream = connect_tcp(hostname, port, bind_ip, family).await?;
+    let tcp_stream = connect_tcp(hostname, port, interface, bind_ip, family).await?;
 
     // Parse server name for TLS
     let server_name: ServerName<'static> = hostname
@@ -110,6 +111,7 @@ pub async fn measure_tls_handshake(
 async fn connect_tcp(
     hostname: &str,
     port: u16,
+    interface: Option<&str>,
     bind_ip: Option<IpAddr>,
     family: Option<IpFamily>,
 ) -> Result<tokio::net::TcpStream> {
@@ -155,6 +157,18 @@ async fn connect_tcp(
         if let Some(ip) = bind_ip {
             if let Err(e) = socket.bind(SocketAddr::new(ip, 0)) {
                 last_err = Some(anyhow!(e).context(format!("failed to bind to {}", ip)));
+                continue;
+            }
+        }
+
+        // Device-bind to the interface where supported (the OS then picks a
+        // source per family); elsewhere the interface was already resolved to
+        // `bind_ip` above, so this is a no-op.
+        if let Some(iface) = interface {
+            if let Err(e) = super::network_bind::bind_socket_to_device(&socket, iface, addr.is_ipv6())
+            {
+                last_err =
+                    Some(anyhow!(e).context(format!("failed to bind to interface {}", iface)));
                 continue;
             }
         }

--- a/src/engine/traceroute.rs
+++ b/src/engine/traceroute.rs
@@ -122,36 +122,15 @@ async fn run_icmp_traceroute(
             .with_context(|| format!("Failed to bind raw ICMP socket to {}", v4))?;
     }
 
-    // On Linux, also pin the socket to the named interface so the kernel
-    // can't reroute the probes via another NIC even if the routing table says so.
-    #[cfg(target_os = "linux")]
+    // Device-bind to the named interface where supported so the kernel can't
+    // reroute the probes via another NIC. The raw socket is IPv4-only here, hence
+    // is_ipv6 = false. On platforms without device binding this is a no-op; the
+    // interface's IPv4 source was already bound via `bind_ip` above.
     if let Some(iface) = interface {
-        use std::ffi::CString;
-        use std::os::unix::io::AsRawFd;
-
-        let ifname = CString::new(iface).map_err(|_| {
-            std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid interface name")
+        super::network_bind::bind_socket_to_device(&socket, iface, false).map_err(|e| {
+            anyhow::anyhow!("Failed to bind raw ICMP socket to interface {}: {}", iface, e)
         })?;
-        unsafe {
-            if libc::setsockopt(
-                socket.as_raw_fd(),
-                libc::SOL_SOCKET,
-                libc::SO_BINDTODEVICE,
-                ifname.as_ptr() as *const libc::c_void,
-                ifname.as_bytes().len() as libc::socklen_t,
-            ) != 0
-            {
-                return Err(anyhow::anyhow!(
-                    "Failed to bind raw ICMP socket to interface {}: {}",
-                    iface,
-                    std::io::Error::last_os_error()
-                ));
-            }
-        }
     }
-
-    #[cfg(not(target_os = "linux"))]
-    let _ = interface;
 
     socket.set_read_timeout(Some(PROBE_TIMEOUT))?;
     socket.set_nonblocking(false)?;

--- a/src/engine/turn_udp.rs
+++ b/src/engine/turn_udp.rs
@@ -292,8 +292,10 @@ async fn bind_and_connect_udp(
     candidates: &[SocketAddr],
     cfg: &RunConfig,
 ) -> Result<(UdpSocket, SocketAddr)> {
-    let bind_addr =
-        network_bind::resolve_bind_address(cfg.interface.as_ref(), cfg.source_ip.as_ref())?;
+    // Source IP comes from --source (or the interface-IP fallback on platforms
+    // without device binding); --interface itself is applied as a device bind in
+    // build_udp_socket so dual-stack candidate selection still works.
+    let bind_addr = cfg.resolved_bind_ip.map(|ip| SocketAddr::new(ip, 0));
 
     let mut last_err: Option<anyhow::Error> = None;
     for &addr in candidates {
@@ -314,60 +316,36 @@ async fn bind_and_connect_udp(
     Err(last_err.unwrap_or_else(|| anyhow!("no UDP candidates to try")))
 }
 
-/// Build a single UDP socket: bind to source IP if set, fall back to an
-/// ephemeral wildcard bind matching the target family otherwise. On Linux,
-/// also apply `SO_BINDTODEVICE` when an interface name is provided so the
-/// kernel can't reroute the packets out a different NIC.
+/// Build a single UDP socket: bind to `bind_addr` (the source IP, or the
+/// interface's resolved IP on platforms without device binding) when set,
+/// otherwise an ephemeral wildcard bind matching the target family. When an
+/// interface name is given on a device-binding platform, pin the socket to that
+/// device so the kernel can't reroute the packets out a different NIC.
 fn build_udp_socket(
     target: SocketAddr,
     bind_addr: Option<SocketAddr>,
     interface: Option<&str>,
 ) -> Result<UdpSocket> {
-    if let Some(addr) = bind_addr {
+    let is_ipv6 = bind_addr.map(|a| a.is_ipv6()).unwrap_or(target.is_ipv6());
+
+    let std_socket: std::net::UdpSocket = if let Some(addr) = bind_addr {
         let domain = socket2::Domain::for_address(addr);
         let socket =
             socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))?;
         socket.bind(&socket2::SockAddr::from(addr))?;
-
-        #[cfg(target_os = "linux")]
-        if let Some(iface) = interface {
-            use std::ffi::CString;
-            use std::os::unix::io::AsRawFd;
-
-            let ifname = CString::new(iface).map_err(|_| {
-                std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid interface name")
-            })?;
-            unsafe {
-                if libc::setsockopt(
-                    socket.as_raw_fd(),
-                    libc::SOL_SOCKET,
-                    libc::SO_BINDTODEVICE,
-                    ifname.as_ptr() as *const libc::c_void,
-                    ifname.as_bytes().len() as libc::socklen_t,
-                ) != 0
-                {
-                    return Err(anyhow!(
-                        "Failed to bind to interface {}: {}",
-                        iface,
-                        std::io::Error::last_os_error()
-                    ));
-                }
-            }
-        }
-
-        #[cfg(not(target_os = "linux"))]
-        let _ = interface;
-
-        let std_socket: std::net::UdpSocket = socket.into();
-        std_socket.set_nonblocking(true)?;
-        Ok(UdpSocket::from_std(std_socket)?)
+        socket.into()
     } else {
         let any = if target.is_ipv4() { "0.0.0.0:0" } else { "[::]:0" };
-        Ok(std::net::UdpSocket::bind(any)
-            .and_then(|s| {
-                s.set_nonblocking(true)?;
-                Ok(s)
-            })
-            .map(UdpSocket::from_std)??)
+        std::net::UdpSocket::bind(any)?
+    };
+
+    // Device binding where supported; a no-op otherwise (the interface was
+    // already resolved to `bind_addr`).
+    if let Some(iface) = interface {
+        network_bind::bind_socket_to_device(&std_socket, iface, is_ipv6)
+            .map_err(|e| anyhow!("Failed to bind to interface {}: {}", iface, e))?;
     }
+
+    std_socket.set_nonblocking(true)?;
+    Ok(UdpSocket::from_std(std_socket)?)
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -640,7 +640,7 @@ fn get_interface_ips(interface_name: Option<&str>) -> (Option<String>, Option<St
 }
 
 /// Check if an IPv6 address is link-local (fe80::/10)
-fn is_link_local_v6(ip: &std::net::Ipv6Addr) -> bool {
+pub fn is_link_local_v6(ip: &std::net::Ipv6Addr) -> bool {
     let segments = ip.segments();
     (segments[0] & 0xffc0) == 0xfe80
 }


### PR DESCRIPTION
## What

Make `--interface` actually usable on dual-stack hosts. Previously `--interface` resolved the interface to a single IP (preferring IPv4) and bound every socket to it, which restricted the whole run to that one address family — so on a host that reaches Cloudflare over IPv6, the test would stall or fail.

Now `--interface` keeps the run dual-stack and binds per family. `--source` is unchanged (still pins one local IP / family).

## How

- **Linux / macOS-like / Solaris**: device binding (`SO_BINDTODEVICE`, or `IP_BOUND_IF`/`IPV6_BOUND_IF`). The OS picks a source address per family, so happy-eyeballs works normally and both A/AAAA are reachable.
- **FreeBSD / Windows** (no device binding): the direct TLS/UDP/traceroute sockets bind the interface's matching-family source per connection. `reqwest` accepts only a single local address (and `hyper-util` then filters connections to that address's family), so for the throughput client we bind the interface source for the family we want:
  - `--ipv4-only` / `--ipv6-only` → that family;
  - unrestricted → the interface's IPv6 source if it has one (prefer IPv6, the faster path); if none is found, leave the client unbound so happy-eyeballs still prefers IPv6 via the routing table — rather than binding IPv4 and forcing the slow v4-only path.

`resolved_bind_ip` now comes from `--source` only, so `--interface` never implies an address-family restriction.

## Notable changes

- `network_bind`: `device_binding_supported()`, `interface_exists()`, `get_interface_ip_for_family()`, family-aware `apply_bind()`, and a shared `bind_socket_to_device()` used by the TLS/UDP/traceroute sockets (replacing the Linux-only inline `SO_BINDTODEVICE` copies; the TLS probe gained interface binding it never had).
- Threaded the interface name (and connection family) into the TLS, external-IP, and IPv4/IPv6-comparison paths.
- Up-front `--interface` validation with a clear error.
- Moved the binding notice out of `build_config` (it was writing to stderr inside the TUI's alternate screen and corrupting the display) into a `bind_notice()` shown only in `--text`/`--json` modes.

## Testing

- Linux: `--interface <nic>` device-binds all sockets and connects over both IPv4 and IPv6; `--source <ip>` binds that IP only; bad interface errors up front.
- FreeBSD (iavf0): `--interface` now runs over IPv6 at full speed (matching no-`--interface`); `-6`/`-4` force the respective family; verified with the binding `strace` and throughput.
- `cargo test` passes; no new clippy warnings.

## Caveat

On platforms without device binding (FreeBSD/Windows), an unrestricted `--interface` run uses a single source family for the throughput client (IPv6-preferred). There's no in-client IPv4 fallback there because `reqwest` doesn't expose binding both source families; use `--ipv4-only` to force IPv4.