### PR TITLE
Termux support (without clipbaord)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ rand = "0.8.5"
 ratatui = { version = "0.30", optional = true, default-features = false, features = ["crossterm"] }
 reqwest = { version = "0.12.9", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "http2", "gzip", "brotli", "deflate", "json", "stream", "socks"] }
 libc = "0.2"
-
 ratatui-textarea = { version = "0.9", optional = true, features = ["search"] }
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.133"
@@ -51,8 +50,11 @@ rustls-native-certs = "0.8"
 # Traceroute (ICMP packet parsing)
 pnet_packet = "0.35"
 
+# Clipboard (arboard) does not support Android. Gate it behind a platform
+# condition so the dependency is simply absent on Android targets, making
+# dep:arboard in the tui feature a harmless no-op there.
 [target.'cfg(not(target_os = "android"))'.dependencies]
-arboard = "3.3"
+arboard = { version = "3.3", optional = true }
 
 [[bin]]
 name = "cloudflare-speed-cli"
@@ -60,7 +62,7 @@ path = "src/main.rs"
 
 [features]
 default = ["tui"]
-tui = ["dep:ratatui", "dep:crossterm", "dep:ratatui-textarea"]
+tui = ["dep:ratatui", "dep:crossterm", "dep:arboard", "dep:ratatui-textarea"]
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rand = "0.8.5"
 ratatui = { version = "0.30", optional = true, default-features = false, features = ["crossterm"] }
 reqwest = { version = "0.12.9", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "http2", "gzip", "brotli", "deflate", "json", "stream", "socks"] }
 libc = "0.2"
-arboard = { version = "3.3", optional = true }
+
 ratatui-textarea = { version = "0.9", optional = true, features = ["search"] }
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.133"
@@ -51,13 +51,16 @@ rustls-native-certs = "0.8"
 # Traceroute (ICMP packet parsing)
 pnet_packet = "0.35"
 
+[target.'cfg(not(target_os = "android"))'.dependencies]
+arboard = "3.3"
+
 [[bin]]
 name = "cloudflare-speed-cli"
 path = "src/main.rs"
 
 [features]
 default = ["tui"]
-tui = ["dep:ratatui", "dep:crossterm", "dep:arboard", "dep:ratatui-textarea"]
+tui = ["dep:ratatui", "dep:crossterm", "dep:ratatui-textarea"]
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/src/network.rs
+++ b/src/network.rs
@@ -134,7 +134,7 @@ fn gather_default_network_info(
 
 /// Get the default network interface name for the given address family.
 /// `None` queries the IPv4 default route (the platform default).
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_default_interface(family: Option<IpFamily>) -> Option<String> {
     // `ip -6 route show default` for IPv6; the v4 table otherwise.
     let route_args: &[&str] = if family == Some(IpFamily::V6) {
@@ -362,7 +362,7 @@ fn get_default_interface(family: Option<IpFamily>) -> Option<String> {
 }
 
 /// Check if interface is wireless
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn check_if_wireless(iface: &str) -> Option<bool> {
     // Check if /sys/class/net/<iface>/wireless exists
     let wireless_path = format!("/sys/class/net/{}/wireless", iface);
@@ -447,7 +447,7 @@ fn check_if_wireless(iface: &str) -> Option<bool> {
 }
 
 /// Get wireless SSID for an interface
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_wireless_ssid(iface: &str) -> Option<String> {
     // Try iwgetid first (most reliable)
     if let Ok(output) = Command::new("iwgetid").arg("-r").arg(iface).output() {
@@ -624,7 +624,7 @@ fn get_wireless_ssid(iface: &str) -> Option<String> {
 }
 
 /// Get MAC address of interface
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_interface_mac(iface: &str) -> Option<String> {
     let mac_path = format!("/sys/class/net/{}/address", iface);
     std::fs::read_to_string(mac_path)

--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -113,21 +113,24 @@ fn init_clipboard_manager() -> Result<&'static std_mpsc::Sender<String>> {
 
         // Spawn a dedicated thread to manage clipboard operations
         std::thread::spawn(move || {
+            #[cfg(not(target_os = "android"))]
             use arboard::Clipboard;
 
+            #[cfg(not(target_os = "android"))]
             for text in rx {
-                // Create a new clipboard instance for each operation
                 if let Ok(mut clipboard) = Clipboard::new() {
-                    // Set the text
                     if clipboard.set_text(&text).is_ok() {
-                        // Keep the clipboard instance alive for 2 seconds
-                        // This gives clipboard managers plenty of time to read the contents
                         std::thread::sleep(Duration::from_secs(2));
                     }
-                    // Clipboard is dropped here
                 }
             }
-        });
+
+            #[cfg(target_os = "android")]
+            for _ in rx {
+                // Clipboard not supported on Android.
+             }
+        }
+        );
 
         tx
     });
@@ -142,9 +145,20 @@ fn init_clipboard_manager() -> Result<&'static std_mpsc::Sender<String>> {
 /// to ensure clipboard managers have time to read the contents on Linux.
 /// Returns immediately after queuing the clipboard operation, without blocking the main thread.
 pub fn copy_to_clipboard(text: &str) -> Result<()> {
-    let sender = init_clipboard_manager()?;
-    sender
-        .send(text.to_string())
-        .map_err(|_| anyhow::anyhow!("Clipboard manager channel closed"))?;
-    Ok(())
+    #[cfg(target_os = "android")]
+    {
+        let _ = text;
+        return Err(anyhow::anyhow!(
+            "Clipboard is not supported on Android"
+        ));
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        let sender = init_clipboard_manager()?;
+        sender
+            .send(text.to_string())
+            .map_err(|_| anyhow::anyhow!("Clipboard manager channel closed"))?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixed the build issue so "arboard" is not set as a required dependency on the Termux environment. Also, the clipboard is not supported on Android (for now; I'll look into it more and see if it can be implemented another way). I also made "network.rs" use the same method for Android as Linux since they're mostly the same. :)