### PR TITLE
Fix history actions hitting the wrong run under filter, plus atomic saves, corrupt-file skip, and working lazy load

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -148,13 +148,18 @@ pub struct Cli {
 
 pub async fn run(args: Cli) -> Result<()> {
     if let Some(p) = args.export_all_csv.as_deref() {
-        let all = crate::storage::load_all()?;
+        let (all, skipped) = crate::storage::load_all_with_skipped()?;
         crate::storage::export_all_csv(p, &all)?;
-        eprintln!(
-            "Exported {} run(s) to {}",
-            all.len(),
-            p.display()
-        );
+        eprintln!("Exported {} run(s) to {}", all.len(), p.display());
+        for s in &skipped {
+            eprintln!("Warning: skipped unreadable run file {}", s.display());
+        }
+        // Documented as "no test is run unless combined with a run mode":
+        // exit here instead of falling through to the TUI (which would
+        // auto-start a test).
+        if !(args.json || args.text || args.silent) {
+            return Ok(());
+        }
     }
 
     // Validate that --silent can only be used with --json
@@ -236,13 +241,15 @@ pub fn build_config(args: &Cli) -> Result<RunConfig> {
         if network_bind::device_binding_supported() {
             None
         } else {
-            Some(network_bind::interface_source_ip(iface, family).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Interface '{}' has no usable {} address",
-                    iface,
-                    family.map(|f| f.label()).unwrap_or("IP")
-                )
-            })?)
+            Some(
+                network_bind::interface_source_ip(iface, family).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Interface '{}' has no usable {} address",
+                        iface,
+                        family.map(|f| f.label()).unwrap_or("IP")
+                    )
+                })?,
+            )
         }
     } else {
         None
@@ -453,8 +460,7 @@ async fn run_text(args: Cli) -> Result<()> {
         Err(e) => return Err(e.into()),
     };
 
-    result.connection_quality =
-        crate::quality::compute(&result, &dl_points, &ul_points);
+    result.connection_quality = crate::quality::compute(&result, &dl_points, &ul_points);
 
     // Gather network information and enrich result
     let network_info = crate::network::gather_network_info(&args);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -48,3 +48,14 @@ pub const MIN_STABILITY_SAMPLES: usize = 3;
 /// a `ThroughputTick`. Also serves as the minimum steady-state window length:
 /// a window shorter than one full interval carries too little signal to report.
 pub const THROUGHPUT_SAMPLE_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Minimum number of additional history entries fetched per lazy-load request
+/// when the History tab selection nears the end of the loaded window.
+pub const HISTORY_LOAD_CHUNK_MIN: usize = 20;
+
+/// Trigger history lazy-loading when the selection is within this many rows of
+/// the end of the visible (filtered) list.
+pub const HISTORY_LAZY_LOAD_THRESHOLD: usize = 10;
+
+/// Rows PageUp/PageDown jump by in the History tab.
+pub const HISTORY_PAGE_SIZE: usize = 20;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -14,24 +14,38 @@ fn runs_dir() -> PathBuf {
     base_dir().join("runs")
 }
 
-/// Ensure the necessary directories exist for storing data.
-pub fn ensure_dirs() -> Result<()> {
-    std::fs::create_dir_all(runs_dir()).context("create runs dir")?;
-    Ok(())
+pub fn save_run(result: &RunResult) -> Result<PathBuf> {
+    save_run_to(&runs_dir(), result)
 }
 
-pub fn save_run(result: &RunResult) -> Result<PathBuf> {
-    ensure_dirs()?;
-    let path = get_run_path(result)?;
+/// Save a run into `dir` (the runs directory). The write is atomic (write to
+/// a temp file, then rename) so a crash or full disk mid-write can never
+/// leave a truncated run file behind.
+fn save_run_to(dir: &Path, result: &RunResult) -> Result<PathBuf> {
+    std::fs::create_dir_all(dir).context("create runs dir")?;
+    let path = run_path_in(dir, result);
     let data = serde_json::to_vec_pretty(result)?;
-    std::fs::write(&path, data).context("write run json")?;
+    let tmp = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&tmp, data) {
+        // Don't leave a partial temp file behind (e.g. disk full mid-write).
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).context("write run json");
+    }
+    if let Err(e) = std::fs::rename(&tmp, &path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).context("finalize run json");
+    }
     Ok(path)
 }
 
-pub fn get_run_path(result: &RunResult) -> Result<PathBuf> {
+fn run_path_in(dir: &Path, result: &RunResult) -> PathBuf {
     let ts = &result.timestamp_utc;
     let safe_ts = ts.replace(':', "-").replace('T', "_");
-    Ok(runs_dir().join(format!("run-{safe_ts}-{}.json", result.meas_id)))
+    dir.join(format!("run-{safe_ts}-{}.json", result.meas_id))
+}
+
+pub fn get_run_path(result: &RunResult) -> Result<PathBuf> {
+    Ok(run_path_in(&runs_dir(), result))
 }
 
 pub fn delete_run(result: &RunResult) -> Result<()> {
@@ -122,11 +136,19 @@ fn csv_row(result: &RunResult) -> String {
         match result.connection_quality.as_ref() {
             Some(cq) => (
                 cq.bufferbloat_grade.clone(),
-                cq.bufferbloat_ms.map(|v| format!("{:.3}", v)).unwrap_or_default(),
+                cq.bufferbloat_ms
+                    .map(|v| format!("{:.3}", v))
+                    .unwrap_or_default(),
                 cq.stability_grade.clone(),
-                cq.stability_cv_pct.map(|v| format!("{:.3}", v)).unwrap_or_default(),
-                cq.stability_cv_download_pct.map(|v| format!("{:.3}", v)).unwrap_or_default(),
-                cq.stability_cv_upload_pct.map(|v| format!("{:.3}", v)).unwrap_or_default(),
+                cq.stability_cv_pct
+                    .map(|v| format!("{:.3}", v))
+                    .unwrap_or_default(),
+                cq.stability_cv_download_pct
+                    .map(|v| format!("{:.3}", v))
+                    .unwrap_or_default(),
+                cq.stability_cv_upload_pct
+                    .map(|v| format!("{:.3}", v))
+                    .unwrap_or_default(),
             ),
             None => (
                 String::new(),
@@ -229,12 +251,14 @@ pub fn export_all_csv(path: &Path, results: &[RunResult]) -> Result<()> {
     Ok(())
 }
 
-/// List run JSON paths newest-first without reading file contents.
-fn list_run_paths(limit: usize) -> Result<Vec<PathBuf>> {
-    ensure_dirs()?;
-    let dir = runs_dir();
+/// List run JSON paths in `dir` newest-first without reading file contents.
+/// A missing directory is treated as an empty history.
+fn list_run_paths_in(dir: &Path, limit: usize) -> Result<Vec<PathBuf>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
     let mut entries: Vec<PathBuf> = Vec::new();
-    for e in std::fs::read_dir(&dir).context("read runs dir")? {
+    for e in std::fs::read_dir(dir).context("read runs dir")? {
         let e = e?;
         let p = e.path();
         if p.extension().and_then(|e| e.to_str()) == Some("json") {
@@ -250,27 +274,138 @@ fn list_run_paths(limit: usize) -> Result<Vec<PathBuf>> {
     Ok(entries)
 }
 
-pub fn load_recent(limit: usize) -> Result<Vec<RunResult>> {
-    let paths = list_run_paths(limit)?;
-    let mut out = Vec::with_capacity(paths.len());
-    for p in paths {
-        let data = std::fs::read(&p).with_context(|| format!("read {}", p.display()))?;
-        let r: RunResult =
-            serde_json::from_slice(&data).with_context(|| format!("parse {}", p.display()))?;
-        out.push(r);
+/// Load up to `limit` runs from `dir` starting `offset` entries into the
+/// newest-first ordering, parsing ONLY that slice. Returns the runs that
+/// parsed plus the paths of files that could not be read or parsed. A single
+/// corrupt file must never make the rest of the history unreachable.
+fn load_runs_range_from(
+    dir: &Path,
+    offset: usize,
+    limit: usize,
+) -> Result<(Vec<RunResult>, Vec<PathBuf>)> {
+    let paths = list_run_paths_in(dir, offset.saturating_add(limit))?;
+    let mut out = Vec::with_capacity(limit.min(paths.len()));
+    let mut skipped = Vec::new();
+    for p in paths.into_iter().skip(offset) {
+        match std::fs::read(&p) {
+            Ok(data) => match serde_json::from_slice::<RunResult>(&data) {
+                Ok(r) => out.push(r),
+                Err(_) => skipped.push(p),
+            },
+            Err(_) => skipped.push(p),
+        }
     }
-    Ok(out)
+    Ok((out, skipped))
 }
 
-/// Load all saved runs, newest first.
-pub fn load_all() -> Result<Vec<RunResult>> {
-    load_recent(usize::MAX)
+fn load_runs_from(dir: &Path, limit: usize) -> Result<(Vec<RunResult>, Vec<PathBuf>)> {
+    load_runs_range_from(dir, 0, limit)
+}
+
+pub fn load_recent(limit: usize) -> Result<Vec<RunResult>> {
+    Ok(load_runs_from(&runs_dir(), limit)?.0)
+}
+
+/// Load `limit` runs starting `offset` entries into the newest-first
+/// ordering. Lets the History tab's lazy loading parse only the next chunk
+/// instead of re-parsing everything already in memory.
+pub fn load_recent_range(offset: usize, limit: usize) -> Result<Vec<RunResult>> {
+    Ok(load_runs_range_from(&runs_dir(), offset, limit)?.0)
+}
+
+/// Load all saved runs newest first, also reporting the files that were
+/// skipped as unreadable/corrupt so callers can warn instead of silently
+/// under-reporting.
+pub fn load_all_with_skipped() -> Result<(Vec<RunResult>, Vec<PathBuf>)> {
+    load_runs_from(&runs_dir(), usize::MAX)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::model::empty_run_result;
+
+    /// Fresh, unique directory under the OS temp dir for storage tests.
+    fn test_dir(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "cloudflare-speed-cli-test-{}-{}",
+            std::process::id(),
+            tag
+        ));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn run_at(ts: &str, meas_id: &str) -> crate::model::RunResult {
+        let mut r = empty_run_result();
+        r.timestamp_utc = ts.into();
+        r.meas_id = meas_id.into();
+        r.base_url = "https://speed.cloudflare.com".into();
+        r
+    }
+
+    #[test]
+    fn load_runs_from_skips_corrupt_files() {
+        let dir = test_dir("skip-corrupt");
+        save_run_to(&dir, &run_at("2026-01-01T00:00:00Z", "aaa")).unwrap();
+        save_run_to(&dir, &run_at("2026-01-02T00:00:00Z", "bbb")).unwrap();
+        // Simulates a file truncated by a crash or full disk mid-write.
+        std::fs::write(dir.join("run-2026-01-03_00-00-00Z-ccc.json"), b"{\"trunc").unwrap();
+
+        let (runs, skipped) = load_runs_from(&dir, 10).unwrap();
+        assert_eq!(
+            runs.iter().map(|r| r.meas_id.as_str()).collect::<Vec<_>>(),
+            vec!["bbb", "aaa"]
+        );
+        assert_eq!(skipped.len(), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_runs_range_parses_only_the_requested_slice() {
+        let dir = test_dir("range");
+        for (ts, id) in [
+            ("2026-01-01T00:00:00Z", "a"),
+            ("2026-01-02T00:00:00Z", "b"),
+            ("2026-01-03T00:00:00Z", "c"),
+            ("2026-01-04T00:00:00Z", "d"),
+            ("2026-01-05T00:00:00Z", "e"),
+        ] {
+            save_run_to(&dir, &run_at(ts, id)).unwrap();
+        }
+        // Newest-first ordering is e,d,c,b,a; offset 2, limit 2 -> c,b.
+        let (runs, skipped) = load_runs_range_from(&dir, 2, 2).unwrap();
+        assert!(skipped.is_empty());
+        assert_eq!(
+            runs.iter().map(|r| r.meas_id.as_str()).collect::<Vec<_>>(),
+            vec!["c", "b"]
+        );
+        // Offset past the end is an empty result, not an error.
+        assert!(load_runs_range_from(&dir, 10, 5).unwrap().0.is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_run_to_roundtrips_without_leftover_temp_files() {
+        let dir = test_dir("roundtrip");
+        let r = run_at("2026-01-01T12:34:56Z", "abc123");
+        save_run_to(&dir, &r).unwrap();
+
+        // Exactly one file, and it is the final .json (no stray tmp files).
+        let names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names.len(), 1, "unexpected files: {names:?}");
+        assert!(names[0].ends_with(".json"), "unexpected files: {names:?}");
+
+        let (runs, skipped) = load_runs_from(&dir, 10).unwrap();
+        assert!(skipped.is_empty());
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].meas_id, "abc123");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn csv_row_includes_p95_p99_columns() {

--- a/src/tui/history.rs
+++ b/src/tui/history.rs
@@ -59,9 +59,9 @@ const MENU_FOOTER_LINE_2: &str = "Esc: close";
 /// depending on whether the selected run already has a comment.
 pub fn menu_labels(state: &UiState) -> [&'static str; MENU_ITEM_COUNT] {
     let has_comment = state
-        .history.runs
-        .get(state.history.selected)
-        .and_then(|r| r.comments.as_deref())
+        .history
+        .selected_run_index()
+        .and_then(|i| state.history.runs[i].comments.as_deref())
         .map(|s| !s.trim().is_empty())
         .unwrap_or(false);
     let comment_label = if has_comment {
@@ -81,28 +81,14 @@ pub fn menu_labels(state: &UiState) -> [&'static str; MENU_ITEM_COUNT] {
 pub fn show_history(area: Rect, f: &mut Frame, state: &mut UiState) {
     let mut lines: Vec<Line> = Vec::new();
 
-    // Filter history based on filter text (case-insensitive search in network_name, interface_name, as_org, colo)
-    let filter_lower = state.history.filter.to_lowercase();
-    let filtered_history: Vec<&RunResult> = if state.history.filter.is_empty() {
-        state.history.runs.iter().collect()
-    } else {
-        state
-            .history.runs
-            .iter()
-            .filter(|r| {
-                let matches_field = |opt: &Option<String>| {
-                    opt.as_ref()
-                        .map(|s| s.to_lowercase().contains(&filter_lower))
-                        .unwrap_or(false)
-                };
-                matches_field(&r.network_name)
-                    || matches_field(&r.interface_name)
-                    || matches_field(&r.as_org)
-                    || matches_field(&r.colo)
-                    || matches_field(&r.comments)
-            })
-            .collect()
-    };
+    // Same filtered view the action handlers resolve through (selected_run_index),
+    // so the highlighted row and the acted-on run can never diverge.
+    let filtered_history: Vec<&RunResult> = state
+        .history
+        .filtered_indices()
+        .into_iter()
+        .map(|i| &state.history.runs[i])
+        .collect();
 
     // Calculate how many items can fit in the available area
     // Subtract 4 for: controls line, filter line (optional), column headers, borders
@@ -117,7 +103,10 @@ pub fn show_history(area: Rect, f: &mut Frame, state: &mut UiState) {
     };
 
     // Build header line with controls
-    let mut header_spans = vec![Span::raw(format!("History ({}/{}", current_pos, total_count))];
+    let mut header_spans = vec![Span::raw(format!(
+        "History ({}/{}",
+        current_pos, total_count
+    ))];
     if !state.history.filter.is_empty() {
         header_spans.push(Span::styled(
             format!(" filtered from {}", state.history.runs.len()),
@@ -399,7 +388,7 @@ pub fn show_history(area: Rect, f: &mut Frame, state: &mut UiState) {
         } else {
             r.network_name
                 .as_deref()
-                .or_else(|| r.interface_name.as_deref())
+                .or(r.interface_name.as_deref())
                 .unwrap_or("-")
         };
         let history_loss_text = r
@@ -523,8 +512,8 @@ pub fn show_history(area: Rect, f: &mut Frame, state: &mut UiState) {
 
     // Render scrollbar on the right edge if there are more items than visible
     if total_count > max_items {
-        let mut scrollbar_state = ScrollbarState::new(total_count.saturating_sub(max_items))
-            .position(scroll_offset);
+        let mut scrollbar_state =
+            ScrollbarState::new(total_count.saturating_sub(max_items)).position(scroll_offset);
         f.render_stateful_widget(
             Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .begin_symbol(Some("↑"))
@@ -542,31 +531,7 @@ pub fn draw_history_detail(area: Rect, f: &mut Frame, state: &mut UiState) {
     // Header with run identity and navigation help
     let mut header_lines: Vec<Line> = Vec::new();
 
-    let filter_lower = state.history.filter.to_lowercase();
-    let filtered_history: Vec<&RunResult> = if state.history.filter.is_empty() {
-        state.history.runs.iter().collect()
-    } else {
-        state
-            .history.runs
-            .iter()
-            .filter(|r| {
-                let matches_field = |opt: &Option<String>| {
-                    opt.as_ref()
-                        .map(|s| s.to_lowercase().contains(&filter_lower))
-                        .unwrap_or(false)
-                };
-                matches_field(&r.network_name)
-                    || matches_field(&r.interface_name)
-                    || matches_field(&r.as_org)
-                    || matches_field(&r.colo)
-                    || matches_field(&r.comments)
-            })
-            .collect()
-    };
-    let effective_selected = state
-        .history
-        .selected
-        .min(filtered_history.len().saturating_sub(1));
+    let selected_run = state.history.selected_run_index();
 
     header_lines.push(Line::from(vec![
         Span::styled("JSON Detail", Style::default().fg(Color::Cyan)),
@@ -579,11 +544,14 @@ pub fn draw_history_detail(area: Rect, f: &mut Frame, state: &mut UiState) {
         Span::raw("/"),
         Span::styled("N", Style::default().fg(Color::Magenta)),
         Span::raw(": next/prev, "),
-        Span::styled("\u{2191}\u{2193}/jk/PgUp/PgDn", Style::default().fg(Color::Magenta)),
+        Span::styled(
+            "\u{2191}\u{2193}/jk/PgUp/PgDn",
+            Style::default().fg(Color::Magenta),
+        ),
         Span::raw(": scroll"),
     ]));
 
-    if let Some(result) = filtered_history.get(effective_selected) {
+    if let Some(result) = selected_run.map(|i| &state.history.runs[i]) {
         let net_label = if state.hide_network_info {
             crate::tui::state::REDACTED_PLACEHOLDER
         } else {
@@ -600,9 +568,15 @@ pub fn draw_history_detail(area: Rect, f: &mut Frame, state: &mut UiState) {
     if state.history.detail_search_editing {
         let mut spans = vec![
             Span::styled("Search: ", Style::default().fg(Color::Cyan)),
-            Span::styled(&state.history.detail_search, Style::default().fg(Color::White)),
+            Span::styled(
+                &state.history.detail_search,
+                Style::default().fg(Color::White),
+            ),
             Span::styled("_", Style::default().fg(Color::Yellow)),
-            Span::styled("  (Enter to confirm, Esc to cancel)", Style::default().fg(Color::Gray)),
+            Span::styled(
+                "  (Enter to confirm, Esc to cancel)",
+                Style::default().fg(Color::Gray),
+            ),
         ];
         if let Some(ref err) = state.history.detail_search_error {
             spans.push(Span::styled(
@@ -614,7 +588,10 @@ pub fn draw_history_detail(area: Rect, f: &mut Frame, state: &mut UiState) {
     } else if !state.history.detail_search.is_empty() {
         header_lines.push(Line::from(vec![
             Span::styled("Search: ", Style::default().fg(Color::Cyan)),
-            Span::styled(&state.history.detail_search, Style::default().fg(Color::Yellow)),
+            Span::styled(
+                &state.history.detail_search,
+                Style::default().fg(Color::Yellow),
+            ),
             Span::styled("  (Esc to clear)", Style::default().fg(Color::Gray)),
         ]));
     }
@@ -701,8 +678,7 @@ pub fn draw_history_menu(area: Rect, f: &mut Frame, state: &UiState) {
     )]));
 
     f.render_widget(Clear, modal_area);
-    let p = Paragraph::new(lines)
-        .block(Block::default().borders(Borders::ALL).title("Actions"));
+    let p = Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title("Actions"));
     f.render_widget(p, modal_area);
 }
 
@@ -731,9 +707,7 @@ pub fn draw_history_comment_modal(area: Rect, f: &mut Frame, state: &UiState) {
     };
 
     f.render_widget(Clear, modal_area);
-    let outer = Block::default()
-        .borders(Borders::ALL)
-        .title("Edit Comment");
+    let outer = Block::default().borders(Borders::ALL).title("Edit Comment");
     let inner_area = outer.inner(modal_area);
     f.render_widget(outer, modal_area);
 
@@ -786,10 +760,9 @@ fn wrap_path(path: &str, width: u16) -> Vec<String> {
             break;
         }
 
-        let mut char_count = 0;
         let mut last_sep_pos = None;
         let mut break_pos = 0;
-        for (idx, ch) in remaining.char_indices() {
+        for (char_count, (idx, ch)) in remaining.char_indices().enumerate() {
             if char_count >= width {
                 break;
             }
@@ -797,7 +770,6 @@ fn wrap_path(path: &str, width: u16) -> Vec<String> {
                 last_sep_pos = Some(idx);
             }
             break_pos = idx + ch.len_utf8();
-            char_count += 1;
         }
 
         let split_pos = match last_sep_pos {
@@ -828,8 +800,7 @@ pub fn draw_history_export_modal(area: Rect, f: &mut Frame, state: &UiState) {
     let path_lines = wrap_path(path, inner_width);
 
     let path_line_count = path_lines.len() as u16;
-    let inner_height =
-        EXPORT_MODAL_HEADER_LINES + path_line_count + EXPORT_MODAL_FOOTER_LINES;
+    let inner_height = EXPORT_MODAL_HEADER_LINES + path_line_count + EXPORT_MODAL_FOOTER_LINES;
     let modal_height = (inner_height + EXPORT_MODAL_BORDER_OVERHEAD).min(area.height);
 
     let x = area.x + area.width.saturating_sub(modal_width) / 2;
@@ -870,7 +841,6 @@ pub fn draw_history_export_modal(area: Rect, f: &mut Frame, state: &UiState) {
     )]));
 
     f.render_widget(Clear, modal_area);
-    let p = Paragraph::new(lines)
-        .block(Block::default().borders(Borders::ALL).title("Export"));
+    let p = Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title("Export"));
     f.render_widget(p, modal_area);
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -33,7 +33,10 @@ use tokio::sync::mpsc;
 
 use charts::draw_charts;
 use dashboard::draw_dashboard;
-use export::{copy_to_clipboard, enrich_result_with_network_info, export_result_csv, export_result_json, save_and_show_path};
+use export::{
+    copy_to_clipboard, enrich_result_with_network_info, export_result_csv, export_result_json,
+    save_and_show_path,
+};
 use help::draw_help;
 use history::{
     draw_history_comment_modal, draw_history_detail, draw_history_export_modal, draw_history_menu,
@@ -67,7 +70,6 @@ pub async fn run(args: Cli) -> Result<()> {
     };
     state.history.initial_load_size = initial_load;
     state.history.runs = crate::storage::load_recent(initial_load).unwrap_or_default();
-    state.history.loaded_count = state.history.runs.len();
     update_available_networks(&mut state);
 
     // Gather network interface information using shared module
@@ -191,25 +193,22 @@ pub async fn run(args: Cli) -> Result<()> {
                         (_, KeyCode::Char('r')) => {
                             // Refresh history (only when on history tab)
                             if state.tab == 1 {
-                                let reload_size = state.history.initial_load_size.max(state.history.loaded_count);
+                                let reload_size = state.history.initial_load_size.max(state.history.runs.len());
                                 match crate::storage::load_recent(reload_size) {
                                     Ok(new_history) => {
                                         let old_count = state.history.runs.len();
                                         state.history.runs = new_history;
-                                        state.history.loaded_count = state.history.runs.len();
+                                        state.history.all_loaded = false;
                                         update_available_networks(&mut state);
 
-                                        // Adjust selection if needed
-                                        if state.history.selected >= state.history.runs.len() && !state.history.runs.is_empty() {
-                                            state.history.selected = state.history.runs.len() - 1;
-                                        } else if state.history.runs.is_empty() {
+                                        // Keep the highlight inside the visible (filtered) list;
+                                        // the renderer re-clamps the scroll offset on the next draw.
+                                        let visible = state.history.visible_len();
+                                        if visible == 0 {
                                             state.history.selected = 0;
                                             state.history.scroll_offset = 0;
-                                        }
-
-                                        // Adjust scroll offset if needed
-                                        if state.history.scroll_offset >= state.history.runs.len() && !state.history.runs.is_empty() {
-                                            state.history.scroll_offset = state.history.runs.len().saturating_sub(20).max(0);
+                                        } else {
+                                            state.history.selected = state.history.selected.min(visible - 1);
                                         }
 
                                         let new_count = state.history.runs.len();
@@ -287,7 +286,7 @@ pub async fn run(args: Cli) -> Result<()> {
                         }
                         (_, KeyCode::Char(' ')) => {
                             if state.tab == 1
-                                && !state.history.runs.is_empty()
+                                && state.history.visible_len() > 0
                                 && !state.history.filter_editing
                                 && !state.history.detail_view
                                 && !state.history.export_modal_open
@@ -315,19 +314,21 @@ pub async fn run(args: Cli) -> Result<()> {
                                 // Dashboard: scroll Test Activity log forward one line.
                                 state.dashboard_log_scroll =
                                     state.dashboard_log_scroll.saturating_sub(1);
-                            } else if state.tab == 1 && !state.history.runs.is_empty() {
-                                if state.history.selected < state.history.runs.len().saturating_sub(1) {
+                            } else if state.tab == 1 {
+                                // Load before moving so the last visible row can still
+                                // pull older entries (or more filter matches) from disk.
+                                lazy_load_more_history(&mut state);
+                                if state.history.selected + 1 < state.history.visible_len() {
                                     state.history.selected += 1;
-
-                                    // Lazy load: if near end of loaded items, load more
-                                    lazy_load_more_history(&mut state);
                                 }
                             }
                         }
                         (_, KeyCode::PageUp) => {
                             if state.tab == 1 && !state.history.runs.is_empty() {
-                                let page_size = 20;
-                                state.history.selected = state.history.selected.saturating_sub(page_size);
+                                state.history.selected = state
+                                    .history
+                                    .selected
+                                    .saturating_sub(crate::constants::HISTORY_PAGE_SIZE);
                             } else if state.tab == 0 {
                                 let max_scroll = state.text_log.len().saturating_sub(1);
                                 state.dashboard_log_scroll =
@@ -338,13 +339,14 @@ pub async fn run(args: Cli) -> Result<()> {
                             if state.tab == 0 {
                                 state.dashboard_log_scroll =
                                     state.dashboard_log_scroll.saturating_sub(10);
-                            } else if state.tab == 1 && !state.history.runs.is_empty() {
-                                let page_size = 20;
-                                let max_idx = state.history.runs.len().saturating_sub(1);
-                                state.history.selected = (state.history.selected + page_size).min(max_idx);
-
-                                // Lazy load if near the end
+                            } else if state.tab == 1 {
                                 lazy_load_more_history(&mut state);
+                                let visible = state.history.visible_len();
+                                if visible > 0 {
+                                    state.history.selected = (state.history.selected
+                                        + crate::constants::HISTORY_PAGE_SIZE)
+                                        .min(visible - 1);
+                                }
                             }
                         }
                         // Filter controls (only on History tab)
@@ -393,8 +395,8 @@ pub async fn run(args: Cli) -> Result<()> {
                                 }
                             }
                         }
-                        (_, KeyCode::Right) | (_, KeyCode::Char('l')) => {
-                            if state.tab == 2 && !state.charts_available_networks.is_empty() {
+                        (_, KeyCode::Right) | (_, KeyCode::Char('l'))
+                            if state.tab == 2 && !state.charts_available_networks.is_empty() => {
                                 // Cycle forwards: All -> first network -> ... -> last network -> All
                                 match &state.charts_network_filter {
                                     None => {
@@ -423,7 +425,6 @@ pub async fn run(args: Cli) -> Result<()> {
                                     }
                                 }
                             }
-                        }
                         _ => {}
                     }
                 }
@@ -522,22 +523,30 @@ pub async fn run(args: Cli) -> Result<()> {
 }
 
 fn lazy_load_more_history(state: &mut UiState) {
-    let load_threshold = state.history.loaded_count.saturating_sub(10);
-    if state.history.selected < load_threshold || state.history.loaded_count != state.history.runs.len() {
+    // Only hit the disk when the highlight is near the end of the visible
+    // list and a previous attempt hasn't already exhausted the run files.
+    if state.history.all_loaded
+        || state.history.selected + crate::constants::HISTORY_LAZY_LOAD_THRESHOLD
+            < state.history.visible_len()
+    {
         return;
     }
-    let current_count = state.history.runs.len();
-    let load_more = current_count.max(20);
-    if let Ok(more_history) = crate::storage::load_recent(load_more) {
-        let existing_ids: std::collections::HashSet<_> =
-            state.history.runs.iter().map(|r| &r.meas_id).collect();
+    let (offset, chunk) = state.history.next_load_range();
+    if let Ok(more_history) = crate::storage::load_recent_range(offset, chunk) {
+        let existing_ids: std::collections::HashSet<_> = state
+            .history
+            .runs
+            .iter()
+            .map(|r| r.meas_id.clone())
+            .collect();
         let new_items: Vec<_> = more_history
             .into_iter()
             .filter(|r| !existing_ids.contains(&r.meas_id))
             .collect();
-        if !new_items.is_empty() {
+        if new_items.is_empty() {
+            state.history.all_loaded = true;
+        } else {
             state.history.runs.extend(new_items);
-            state.history.loaded_count = state.history.runs.len();
             update_available_networks(state);
         }
     }
@@ -679,10 +688,9 @@ fn apply_event(state: &mut UiState, ev: TestEvent) {
                             UiState::push_point(&mut state.latency.loaded_dl_lat_points, t, ms);
                             state.latency.loaded_dl_latency_samples.push(ms);
                             if state.latency.loaded_dl_latency_samples.len() > 10000 {
-                                state
-                                    .latency
-                                    .loaded_dl_latency_samples
-                                    .drain(0..(state.latency.loaded_dl_latency_samples.len() - 10000));
+                                state.latency.loaded_dl_latency_samples.drain(
+                                    0..(state.latency.loaded_dl_latency_samples.len() - 10000),
+                                );
                             }
                         }
                     }
@@ -697,10 +705,9 @@ fn apply_event(state: &mut UiState, ev: TestEvent) {
                             UiState::push_point(&mut state.latency.loaded_ul_lat_points, t, ms);
                             state.latency.loaded_ul_latency_samples.push(ms);
                             if state.latency.loaded_ul_latency_samples.len() > 10000 {
-                                state
-                                    .latency
-                                    .loaded_ul_latency_samples
-                                    .drain(0..(state.latency.loaded_ul_latency_samples.len() - 10000));
+                                state.latency.loaded_ul_latency_samples.drain(
+                                    0..(state.latency.loaded_ul_latency_samples.len() - 10000),
+                                );
                             }
                         }
                     }
@@ -721,22 +728,32 @@ fn apply_event(state: &mut UiState, ev: TestEvent) {
                     state.throughput.dl_bytes_total = bytes_total;
                     if let Some(t0) = state.throughput.dl_phase_start {
                         let secs = t0.elapsed().as_secs_f64().max(1e-9);
-                        state.throughput.dl_avg_mbps = ((bytes_total as f64) / secs) * 8.0 / 1_000_000.0;
+                        state.throughput.dl_avg_mbps =
+                            ((bytes_total as f64) / secs) * 8.0 / 1_000_000.0;
                     }
                     let v = state.throughput.dl_mbps.round().clamp(0.0, 10_000.0) as u64;
                     UiState::push_series(&mut state.throughput.dl_series, v);
-                    UiState::push_point(&mut state.throughput.dl_points, t, state.throughput.dl_mbps.max(0.0));
+                    UiState::push_point(
+                        &mut state.throughput.dl_points,
+                        t,
+                        state.throughput.dl_mbps.max(0.0),
+                    );
                 }
                 Phase::Upload => {
                     state.throughput.ul_mbps = mbps;
                     state.throughput.ul_bytes_total = bytes_total;
                     if let Some(t0) = state.throughput.ul_phase_start {
                         let secs = t0.elapsed().as_secs_f64().max(1e-9);
-                        state.throughput.ul_avg_mbps = ((bytes_total as f64) / secs) * 8.0 / 1_000_000.0;
+                        state.throughput.ul_avg_mbps =
+                            ((bytes_total as f64) / secs) * 8.0 / 1_000_000.0;
                     }
                     let v = state.throughput.ul_mbps.round().clamp(0.0, 10_000.0) as u64;
                     UiState::push_series(&mut state.throughput.ul_series, v);
-                    UiState::push_point(&mut state.throughput.ul_points, t, state.throughput.ul_mbps.max(0.0));
+                    UiState::push_point(
+                        &mut state.throughput.ul_points,
+                        t,
+                        state.throughput.ul_mbps.max(0.0),
+                    );
                 }
                 _ => {}
             }
@@ -831,10 +848,10 @@ fn apply_event(state: &mut UiState, ev: TestEvent) {
 }
 
 fn open_history_detail(state: &mut UiState) {
-    if state.history.runs.is_empty() || state.history.selected >= state.history.runs.len() {
+    let Some(idx) = state.history.selected_run_index() else {
         return;
-    }
-    let r = &state.history.runs[state.history.selected];
+    };
+    let r = &state.history.runs[idx];
     let json = serde_json::to_string_pretty(r)
         .unwrap_or_else(|e| format!("Error serializing JSON: {}", e));
     let lines: Vec<String> = json.lines().map(String::from).collect();
@@ -976,10 +993,10 @@ fn open_export_modal(state: &mut UiState, path: String) {
 }
 
 fn export_history_selected_json(state: &mut UiState) {
-    if state.history.runs.is_empty() || state.history.selected >= state.history.runs.len() {
+    let Some(idx) = state.history.selected_run_index() else {
         return;
-    }
-    let r = &state.history.runs[state.history.selected];
+    };
+    let r = &state.history.runs[idx];
     match export_result_json(r, state) {
         Ok(p) => open_export_modal(state, p.to_string_lossy().to_string()),
         Err(e) => state.info = format!("JSON export failed: {e:#}"),
@@ -987,10 +1004,10 @@ fn export_history_selected_json(state: &mut UiState) {
 }
 
 fn export_history_selected_csv(state: &mut UiState) {
-    if state.history.runs.is_empty() || state.history.selected >= state.history.runs.len() {
+    let Some(idx) = state.history.selected_run_index() else {
         return;
-    }
-    let r = &state.history.runs[state.history.selected];
+    };
+    let r = &state.history.runs[idx];
     match export_result_csv(r, state) {
         Ok(p) => open_export_modal(state, p.to_string_lossy().to_string()),
         Err(e) => state.info = format!("CSV export failed: {e:#}"),
@@ -998,13 +1015,10 @@ fn export_history_selected_csv(state: &mut UiState) {
 }
 
 fn open_comment_modal(state: &mut UiState) {
-    if state.history.runs.is_empty() || state.history.selected >= state.history.runs.len() {
+    let Some(idx) = state.history.selected_run_index() else {
         return;
-    }
-    let existing = state.history.runs[state.history.selected]
-        .comments
-        .clone()
-        .unwrap_or_default();
+    };
+    let existing = state.history.runs[idx].comments.clone().unwrap_or_default();
     let lines = if existing.is_empty() {
         vec![String::new()]
     } else {
@@ -1027,7 +1041,7 @@ fn handle_history_comment_modal_key(state: &mut UiState, k: crossterm::event::Ke
             state.history.comment_modal_textarea = ratatui_textarea::TextArea::default();
         }
         KeyCode::Enter => {
-            if state.history.selected < state.history.runs.len() {
+            if let Some(idx) = state.history.selected_run_index() {
                 let value = state
                     .history
                     .comment_modal_textarea
@@ -1036,8 +1050,8 @@ fn handle_history_comment_modal_key(state: &mut UiState, k: crossterm::event::Ke
                     .trim()
                     .to_string();
                 let new_comment = if value.is_empty() { None } else { Some(value) };
-                state.history.runs[state.history.selected].comments = new_comment;
-                if let Err(e) = crate::storage::save_run(&state.history.runs[state.history.selected]) {
+                state.history.runs[idx].comments = new_comment;
+                if let Err(e) = crate::storage::save_run(&state.history.runs[idx]) {
                     state.info = format!("Save comment failed: {e:#}");
                 } else {
                     state.info = "Comment saved".into();
@@ -1072,24 +1086,25 @@ fn handle_history_export_modal_key(state: &mut UiState, code: KeyCode) {
 }
 
 fn delete_history_selected(state: &mut UiState) {
-    if state.history.runs.is_empty() || state.history.selected >= state.history.runs.len() {
+    let Some(idx) = state.history.selected_run_index() else {
         return;
-    }
-    let to_delete = state.history.runs[state.history.selected].clone();
+    };
+    let to_delete = state.history.runs[idx].clone();
     if let Err(e) = crate::storage::delete_run(&to_delete) {
         state.info = format!("Delete failed: {e:#}");
         return;
     }
-    state.history.runs.remove(state.history.selected);
-    if state.history.scroll_offset >= state.history.runs.len() && !state.history.runs.is_empty() {
-        state.history.scroll_offset = state.history.runs.len().saturating_sub(20).max(0);
-    }
-    if state.history.selected >= state.history.runs.len() && !state.history.runs.is_empty() {
-        state.history.selected = state.history.runs.len() - 1;
-    } else if state.history.runs.is_empty() {
+    state.history.runs.remove(idx);
+    // Keep the highlight inside the now-shorter visible list; the renderer
+    // re-clamps the scroll offset on the next draw.
+    let visible = state.history.visible_len();
+    if visible == 0 {
         state.history.selected = 0;
         state.history.scroll_offset = 0;
+    } else {
+        state.history.selected = state.history.selected.min(visible - 1);
     }
+    update_available_networks(state);
     state.info = "Deleted".into();
 }
 
@@ -1127,10 +1142,7 @@ fn draw(area: Rect, f: &mut ratatui::Frame, state: &mut UiState) {
         .constraints([Constraint::Length(3), Constraint::Min(0)].as_ref())
         .split(area);
 
-    let mut tab_titles: Vec<Line> = vec![
-        Line::from("Dashboard"),
-        Line::from("History"),
-    ];
+    let mut tab_titles: Vec<Line> = vec![Line::from("Dashboard"), Line::from("History")];
     if state.diagnostics.traceroute_enabled {
         tab_titles.push(Line::from("Traceroute"));
     }
@@ -1138,24 +1150,44 @@ fn draw(area: Rect, f: &mut ratatui::Frame, state: &mut UiState) {
     tab_titles.push(Line::from("Help"));
 
     let tabs = Tabs::new(tab_titles)
-    .select(state.tab)
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(match &state.update_status {
-                Some(Some(v)) => Line::from(vec![
-                    Span::raw(format!("cloudflare-speed-cli v{} ", env!("CARGO_PKG_VERSION"))),
-                    Span::styled(format!("(v{} available)", v), Style::default().fg(Color::Cyan)),
-                ]),
-                Some(None) => Line::from(format!("cloudflare-speed-cli v{} (latest)", env!("CARGO_PKG_VERSION"))),
-                None => Line::from(format!("cloudflare-speed-cli v{}", env!("CARGO_PKG_VERSION"))),
-            }),
-    )
-    .highlight_style(Style::default().fg(Color::Yellow));
+        .select(state.tab)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(match &state.update_status {
+                    Some(Some(v)) => Line::from(vec![
+                        Span::raw(format!(
+                            "cloudflare-speed-cli v{} ",
+                            env!("CARGO_PKG_VERSION")
+                        )),
+                        Span::styled(
+                            format!("(v{} available)", v),
+                            Style::default().fg(Color::Cyan),
+                        ),
+                    ]),
+                    Some(None) => Line::from(format!(
+                        "cloudflare-speed-cli v{} (latest)",
+                        env!("CARGO_PKG_VERSION")
+                    )),
+                    None => Line::from(format!(
+                        "cloudflare-speed-cli v{}",
+                        env!("CARGO_PKG_VERSION")
+                    )),
+                }),
+        )
+        .highlight_style(Style::default().fg(Color::Yellow));
     f.render_widget(tabs, chunks[0]);
 
-    let traceroute_idx: Option<usize> = if state.diagnostics.traceroute_enabled { Some(2) } else { None };
-    let charts_idx: usize = if state.diagnostics.traceroute_enabled { 3 } else { 2 };
+    let traceroute_idx: Option<usize> = if state.diagnostics.traceroute_enabled {
+        Some(2)
+    } else {
+        None
+    };
+    let charts_idx: usize = if state.diagnostics.traceroute_enabled {
+        3
+    } else {
+        2
+    };
 
     match state.tab {
         0 => draw_dashboard(chunks[1], f, state),

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,11 +1,13 @@
-use crate::model::{DnsSummary, IpVersionComparison, Phase, RunResult, TlsSummary, TracerouteHop, TracerouteSummary};
+use crate::model::{
+    DnsSummary, IpVersionComparison, Phase, RunResult, TlsSummary, TracerouteHop, TracerouteSummary,
+};
 use ratatui::{
     style::Color,
     style::Style,
     text::{Line, Span},
 };
-use std::time::Instant;
 use ratatui_textarea::TextArea;
+use std::time::Instant;
 
 #[derive(Default)]
 pub struct ThroughputUi {
@@ -50,7 +52,9 @@ pub struct HistoryUi {
     pub runs: Vec<RunResult>,
     pub selected: usize,
     pub scroll_offset: usize,
-    pub loaded_count: usize,
+    /// Set once a lazy load finds nothing new on disk, so scrolling at the
+    /// end of the list stops re-scanning the runs directory on every keypress.
+    pub all_loaded: bool,
     pub initial_load_size: usize,
     pub filter: String,
     pub filter_editing: bool,
@@ -74,7 +78,7 @@ impl Default for HistoryUi {
             runs: Vec::new(),
             selected: 0,
             scroll_offset: 0,
-            loaded_count: 0,
+            all_loaded: false,
             initial_load_size: 66,
             filter: String::new(),
             filter_editing: false,
@@ -91,6 +95,68 @@ impl Default for HistoryUi {
             comment_modal_open: false,
             comment_modal_textarea: TextArea::default(),
         }
+    }
+}
+
+impl HistoryUi {
+    /// True when `r` matches the active filter text (already lowercased).
+    /// Searched fields: network name, interface, AS org, colo, comments.
+    pub fn run_matches_filter(r: &RunResult, filter_lower: &str) -> bool {
+        let matches_field = |opt: &Option<String>| {
+            opt.as_ref()
+                .map(|s| s.to_lowercase().contains(filter_lower))
+                .unwrap_or(false)
+        };
+        matches_field(&r.network_name)
+            || matches_field(&r.interface_name)
+            || matches_field(&r.as_org)
+            || matches_field(&r.colo)
+            || matches_field(&r.comments)
+    }
+
+    /// Indices into `runs` of the rows the History tab currently shows,
+    /// in display order. Identity when no filter is active.
+    pub fn filtered_indices(&self) -> Vec<usize> {
+        if self.filter.is_empty() {
+            return (0..self.runs.len()).collect();
+        }
+        let filter_lower = self.filter.to_lowercase();
+        self.runs
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| Self::run_matches_filter(r, &filter_lower))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Number of rows the History tab currently shows.
+    pub fn visible_len(&self) -> usize {
+        self.filtered_indices().len()
+    }
+
+    /// Index into `runs` of the highlighted row, honoring the active filter.
+    /// `None` when nothing is visible. This is the ONLY correct way for an
+    /// action (delete/export/comment/detail) to resolve the selected run.
+    pub fn selected_run_index(&self) -> Option<usize> {
+        let visible = self.filtered_indices();
+        if visible.is_empty() {
+            None
+        } else {
+            // Clamp like the renderer does, so the highlighted row and the
+            // acted-on row can never diverge.
+            Some(visible[self.selected.min(visible.len() - 1)])
+        }
+    }
+
+    /// The (offset, chunk) to request from storage on the next lazy load:
+    /// only entries beyond those already in memory, one chunk at a time, so
+    /// scrolling never re-parses the files already loaded.
+    pub fn next_load_range(&self) -> (usize, usize) {
+        (
+            self.runs.len(),
+            self.initial_load_size
+                .max(crate::constants::HISTORY_LOAD_CHUNK_MIN),
+        )
     }
 }
 
@@ -304,7 +370,6 @@ impl UiState {
             return;
         }
         self.history.runs.insert(0, run);
-        self.history.loaded_count = self.history.runs.len();
         update_available_networks(self);
     }
 
@@ -362,5 +427,84 @@ impl UiState {
                 ..Default::default()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::empty_run_result;
+
+    fn run_with_network(name: &str) -> RunResult {
+        let mut r = empty_run_result();
+        r.network_name = Some(name.into());
+        r
+    }
+
+    fn history_with_networks(names: &[&str]) -> HistoryUi {
+        HistoryUi {
+            runs: names.iter().map(|n| run_with_network(n)).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn filtered_indices_identity_without_filter() {
+        let h = history_with_networks(&["HomeWifi", "Office", "home-5g"]);
+        assert_eq!(h.filtered_indices(), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn filtered_indices_respect_active_filter() {
+        let mut h = history_with_networks(&["HomeWifi", "Office", "home-5g"]);
+        h.filter = "Home".into();
+        assert_eq!(h.filtered_indices(), vec![0, 2]);
+    }
+
+    #[test]
+    fn selected_run_index_resolves_through_filter() {
+        let mut h = history_with_networks(&["HomeWifi", "Office", "home-5g"]);
+        h.filter = "home".into();
+        // Highlighting the second visible row must resolve to runs[2],
+        // not runs[1] (which the filter hides).
+        h.selected = 1;
+        assert_eq!(h.selected_run_index(), Some(2));
+    }
+
+    #[test]
+    fn selected_run_index_clamps_to_last_visible_row() {
+        let mut h = history_with_networks(&["HomeWifi", "Office", "home-5g"]);
+        h.filter = "home".into();
+        h.selected = 99;
+        assert_eq!(h.selected_run_index(), Some(2));
+    }
+
+    #[test]
+    fn selected_run_index_none_when_filter_matches_nothing() {
+        let mut h = history_with_networks(&["HomeWifi", "Office"]);
+        h.filter = "zzz".into();
+        h.selected = 0;
+        assert_eq!(h.selected_run_index(), None);
+    }
+
+    #[test]
+    fn selected_run_index_none_when_empty() {
+        let h = HistoryUi::default();
+        assert_eq!(h.selected_run_index(), None);
+    }
+
+    #[test]
+    fn next_load_range_starts_beyond_loaded_entries() {
+        let h = HistoryUi {
+            runs: (0..66).map(|_| empty_run_result()).collect(),
+            ..Default::default()
+        };
+        let (offset, chunk) = h.next_load_range();
+        assert_eq!(
+            offset,
+            h.runs.len(),
+            "lazy load must skip what is already in memory"
+        );
+        assert!(chunk > 0, "lazy load must actually request new entries");
     }
 }


### PR DESCRIPTION
Fixes a data-loss bug and several history/storage issues found in a full-repo audit.

- With a filter active, delete/detail/comment/export acted on the raw selection index into the unfiltered list, so they could hit (and permanently delete) an invisible unrelated run. All actions and the renderer now resolve through shared `filtered_indices()` / `selected_run_index()` helpers on `HistoryUi`, with unit tests covering the mapping.
- Run saves are atomic (temp file + rename), so a crash or full disk can no longer leave a truncated run file.
- One corrupt run file no longer makes the entire history unloadable; it is skipped and reported.
- Lazy loading of older history was a no-op (it re-requested exactly what was already in memory and deduped it all away); it now requests the next chunk by offset, and stops rescanning the disk once exhausted.
- `--export-all-csv` alone now exports and exits instead of falling through to the TUI and auto-starting a test, matching its help text. It also warns about skipped corrupt files.
