### PR TITLE
Restore the terminal on every exit path via RAII guard and panic hook

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -41,8 +41,39 @@ use history::{
 };
 use state::update_available_networks;
 
+/// Puts the user's shell back in order: raw mode off, alternate screen left.
+/// Safe to call more than once.
+fn restore_terminal() {
+    let _ = disable_raw_mode();
+    let _ = execute!(io::stdout(), LeaveAlternateScreen);
+}
+
+/// Restores the terminal on drop, so every exit path out of `run` (normal
+/// return, `?` early return, or panic unwinding) leaves the shell usable
+/// instead of stuck in raw mode inside the alternate screen.
+struct TerminalRestoreGuard;
+
+impl Drop for TerminalRestoreGuard {
+    fn drop(&mut self) {
+        restore_terminal();
+    }
+}
+
 pub async fn run(args: Cli) -> Result<()> {
+    // Restore the terminal before the panic message prints; otherwise it
+    // lands invisible inside the alternate screen and the shell needs `reset`.
+    // Every panic is then fatal: the hook fires for spawned-task panics too,
+    // and once the terminal is restored the TUI must not keep drawing into
+    // the primary screen, so exit instead of limping on.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        restore_terminal();
+        original_hook(info);
+        std::process::exit(1);
+    }));
+
     enable_raw_mode().context("enable raw mode")?;
+    let _restore_guard = TerminalRestoreGuard;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen).ok();
 
@@ -514,10 +545,8 @@ pub async fn run(args: Cli) -> Result<()> {
         }
     };
 
-    // Restore terminal.
-    disable_raw_mode().ok();
-    let mut stdout = io::stdout();
-    execute!(stdout, LeaveAlternateScreen).ok();
+    // _restore_guard's Drop restores the terminal here and on every early
+    // return above.
     res
 }
 


### PR DESCRIPTION
Previously, any error after entering the alternate screen (for example a typo like `--source not-an-ip` with test-on-launch, or an error on rerun) propagated with `?` past the restore code, leaving the shell in raw mode until the user ran `reset`. Panics had the same problem, with the message printed invisibly inside the alternate screen.

- `TerminalRestoreGuard` (RAII Drop) restores raw mode and leaves the alternate screen on every exit path out of `tui::run`.
- A panic hook restores the terminal first so the panic message prints readably, then exits; once the terminal is restored the TUI must not keep drawing, so panics are treated as fatal.