### PR TITLE
Fix measurement accuracy: steady-state trimming, real pause and cancel, UDP late-response crediting, ICMP reply validation

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -12,6 +12,29 @@ pub const META_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 /// the overall request timeout.
 pub const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Fraction of a throughput phase treated as ramp-up (TCP slow start / buffer
+/// fill) and excluded from steady-state reporting and stability CV.
+pub const STEADY_STATE_RAMP_FRACTION: f64 = 0.20;
+
+/// Minimum ramp-up exclusion regardless of phase length.
+pub const STEADY_STATE_MIN_RAMP: Duration = Duration::from_secs(1);
+
+/// Poll cadence while a phase or worker waits for a pause to lift.
+pub const PAUSE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Backoff after a failed throughput request so an unreachable server does
+/// not turn the workers into a hot loop.
+pub const WORKER_ERROR_BACKOFF: Duration = Duration::from_millis(100);
+
+/// Per-probe response deadline for the UDP loss probe.
+pub const UDP_PROBE_TIMEOUT: Duration = Duration::from_millis(600);
+
+/// Delay between UDP loss probes.
+pub const UDP_PROBE_INTERVAL: Duration = Duration::from_millis(80);
+
+/// Latency probes per family in the IPv4-vs-IPv6 comparison (median reported).
+pub const IP_COMPARISON_LATENCY_PROBES: usize = 5;
+
 /// Waveform-style bufferbloat thresholds: (max latency increase in ms, grade).
 /// The first row whose threshold the measured value is <= to wins.
 /// `f64::INFINITY` serves as the catch-all for F.

--- a/src/engine/ip_comparison.rs
+++ b/src/engine/ip_comparison.rs
@@ -7,6 +7,7 @@ use crate::model::{IpVersionComparison, IpVersionResult};
 use anyhow::Result;
 use reqwest::Url;
 use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use tokio::net::lookup_host;
 
@@ -24,6 +25,7 @@ pub async fn compare_ip_versions(
     bind_ip: Option<IpAddr>,
     cert_path: Option<&std::path::Path>,
     family: Option<IpFamily>,
+    cancel: &AtomicBool,
 ) -> Result<IpVersionComparison> {
     let url = Url::parse(base_url)?;
     let hostname = url
@@ -56,19 +58,29 @@ pub async fn compare_ip_versions(
     let test_v6 = family != Some(IpFamily::V4);
 
     // Test IPv4
-    let ipv4_result = Some(if !test_v4 {
+    let ipv4_result = Some(if cancel.load(Ordering::Relaxed) {
+        unavailable_result("Cancelled")
+    } else if !test_v4 {
         skipped_result(family)
     } else if let Some(ip) = ipv4_addr {
-        test_ip_version(base_url, hostname, port, ip, user_agent, interface, bind_ip, cert_path).await
+        test_ip_version(
+            base_url, hostname, port, ip, user_agent, interface, bind_ip, cert_path, cancel,
+        )
+        .await
     } else {
         unavailable_result("No IPv4 address resolved")
     });
 
     // Test IPv6
-    let ipv6_result = Some(if !test_v6 {
+    let ipv6_result = Some(if cancel.load(Ordering::Relaxed) {
+        unavailable_result("Cancelled")
+    } else if !test_v6 {
         skipped_result(family)
     } else if let Some(ip) = ipv6_addr {
-        test_ip_version(base_url, hostname, port, ip, user_agent, interface, bind_ip, cert_path).await
+        test_ip_version(
+            base_url, hostname, port, ip, user_agent, interface, bind_ip, cert_path, cancel,
+        )
+        .await
     } else {
         unavailable_result("No IPv6 address resolved")
     });
@@ -110,6 +122,7 @@ async fn test_ip_version(
     interface: Option<&str>,
     bind_ip: Option<IpAddr>,
     cert_path: Option<&std::path::Path>,
+    cancel: &AtomicBool,
 ) -> IpVersionResult {
     use super::network_bind;
 
@@ -150,7 +163,7 @@ async fn test_ip_version(
     };
 
     // Measure latency first
-    let latency_ms = match measure_latency(&client, base_url).await {
+    let latency_ms = match measure_latency(&client, base_url, cancel).await {
         Ok(lat) => lat,
         Err(e) => {
             return IpVersionResult {
@@ -165,7 +178,7 @@ async fn test_ip_version(
     };
 
     // Run abbreviated download test
-    let download_mbps = match run_download_test(&client, base_url, TEST_DURATION).await {
+    let download_mbps = match run_download_test(&client, base_url, TEST_DURATION, cancel).await {
         Ok(mbps) => mbps,
         Err(e) => {
             return IpVersionResult {
@@ -180,7 +193,7 @@ async fn test_ip_version(
     };
 
     // Run abbreviated upload test
-    let upload_mbps = match run_upload_test(&client, base_url, TEST_DURATION).await {
+    let upload_mbps = match run_upload_test(&client, base_url, TEST_DURATION, cancel).await {
         Ok(mbps) => mbps,
         Err(e) => {
             return IpVersionResult {
@@ -204,12 +217,33 @@ async fn test_ip_version(
     }
 }
 
-/// Measure latency to the server.
-async fn measure_latency(client: &reqwest::Client, base_url: &str) -> Result<f64> {
+/// Measure request latency on a warm connection: one throwaway request
+/// establishes TCP+TLS, then the median of several tiny requests is reported.
+/// This keeps the number comparable to the main test's probe latency instead
+/// of ~3x the path RTT (connect + handshake + TTFB).
+async fn measure_latency(
+    client: &reqwest::Client,
+    base_url: &str,
+    cancel: &AtomicBool,
+) -> Result<f64> {
     let url = format!("{}/__down?bytes=0", base_url);
-    let start = Instant::now();
-    let _resp = client.get(&url).send().await?;
-    Ok(start.elapsed().as_secs_f64() * 1000.0)
+    let warmup = client.get(&url).send().await?.error_for_status()?;
+    let _ = warmup.bytes().await;
+
+    let mut samples = Vec::with_capacity(crate::constants::IP_COMPARISON_LATENCY_PROBES);
+    for _ in 0..crate::constants::IP_COMPARISON_LATENCY_PROBES {
+        if cancel.load(Ordering::Relaxed) {
+            break;
+        }
+        let start = Instant::now();
+        let resp = client.get(&url).send().await?.error_for_status()?;
+        let _ = resp.bytes().await;
+        samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    crate::metrics::compute_sample_metrics(&samples)
+        .map(|m| m.median)
+        .ok_or_else(|| anyhow::anyhow!("no latency samples collected"))
 }
 
 /// Run abbreviated download test.
@@ -217,13 +251,14 @@ async fn run_download_test(
     client: &reqwest::Client,
     base_url: &str,
     duration: Duration,
+    cancel: &AtomicBool,
 ) -> Result<f64> {
     let url = format!("{}/__down?bytes=5000000", base_url); // 5MB chunks
     let start = Instant::now();
     let mut total_bytes: u64 = 0;
 
-    while start.elapsed() < duration {
-        let resp = client.get(&url).send().await?;
+    while start.elapsed() < duration && !cancel.load(Ordering::Relaxed) {
+        let resp = client.get(&url).send().await?.error_for_status()?;
         let bytes = resp.bytes().await?;
         total_bytes += bytes.len() as u64;
     }
@@ -238,14 +273,20 @@ async fn run_upload_test(
     client: &reqwest::Client,
     base_url: &str,
     duration: Duration,
+    cancel: &AtomicBool,
 ) -> Result<f64> {
     let url = format!("{}/__up", base_url);
     let upload_data = vec![0u8; 5_000_000]; // 5MB chunks
     let start = Instant::now();
     let mut total_bytes: u64 = 0;
 
-    while start.elapsed() < duration {
-        let _resp = client.post(&url).body(upload_data.clone()).send().await?;
+    while start.elapsed() < duration && !cancel.load(Ordering::Relaxed) {
+        client
+            .post(&url)
+            .body(upload_data.clone())
+            .send()
+            .await?
+            .error_for_status()?;
         total_bytes += upload_data.len() as u64;
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -110,10 +110,11 @@ impl TestEngine {
 
         // Final fallback to response headers
         if meta.is_none() {
-            meta = tokio::time::timeout(meta_timeout, cloudflare::fetch_meta_from_response(&client))
-                .await
-                .ok()
-                .and_then(Result::ok);
+            meta =
+                tokio::time::timeout(meta_timeout, cloudflare::fetch_meta_from_response(&client))
+                    .await
+                    .ok()
+                    .and_then(Result::ok);
         }
 
         let locations =
@@ -164,7 +165,7 @@ impl TestEngine {
         let mut external_ipv6: Option<String> = None;
 
         // DNS Resolution measurement
-        if self.cfg.measure_dns {
+        if self.cfg.measure_dns && !cancel.load(Ordering::Relaxed) {
             if let Some(hostname) = dns::extract_hostname(&self.cfg.base_url) {
                 event_tx
                     .send(TestEvent::Info {
@@ -196,7 +197,7 @@ impl TestEngine {
         }
 
         // TLS Handshake measurement
-        if self.cfg.measure_tls {
+        if self.cfg.measure_tls && !cancel.load(Ordering::Relaxed) {
             if let Some((hostname, port)) = tls::extract_host_port(&self.cfg.base_url) {
                 event_tx
                     .send(TestEvent::Info {
@@ -237,7 +238,7 @@ impl TestEngine {
         }
 
         // Fetch external IPs (runs in parallel, part of default diagnostics)
-        if self.cfg.measure_dns {
+        if self.cfg.measure_dns && !cancel.load(Ordering::Relaxed) {
             let (v4, v6) = dns::fetch_external_ips(
                 &self.cfg.base_url,
                 self.cfg.interface.as_deref(),
@@ -255,7 +256,7 @@ impl TestEngine {
         }
 
         // IPv4 vs IPv6 comparison
-        if self.cfg.compare_ip_versions {
+        if self.cfg.compare_ip_versions && !cancel.load(Ordering::Relaxed) {
             event_tx
                 .send(TestEvent::Info {
                     message: "Comparing IPv4 vs IPv6 performance...".to_string(),
@@ -270,6 +271,7 @@ impl TestEngine {
                 self.cfg.resolved_bind_ip,
                 self.cfg.certificate_path.as_deref(),
                 family,
+                &cancel,
             )
             .await
             {
@@ -294,7 +296,7 @@ impl TestEngine {
         }
 
         // Traceroute
-        if self.cfg.traceroute {
+        if self.cfg.traceroute && !cancel.load(Ordering::Relaxed) {
             if let Some(hostname) = dns::extract_hostname(&self.cfg.base_url) {
                 event_tx
                     .send(TestEvent::Info {
@@ -313,6 +315,7 @@ impl TestEngine {
                     self.cfg.resolved_bind_ip,
                     self.cfg.interface.as_deref(),
                     family,
+                    cancel.clone(),
                 )
                 .await
                 {
@@ -414,19 +417,25 @@ impl TestEngine {
         // Use prefetched DNS if available (empty Vec means resolve inline)
         let pre_resolved: Vec<std::net::SocketAddr> = stun_dns_handle.await.unwrap_or_default();
 
-        match turn_udp::run_udp_like_loss_probe(&info, &self.cfg, &event_tx, pre_resolved, family)
+        if !cancel.load(Ordering::Relaxed) {
+            match turn_udp::run_udp_like_loss_probe(
+                &info,
+                &self.cfg,
+                &event_tx,
+                pre_resolved,
+                family,
+                &cancel,
+            )
             .await
-        {
-            Ok(udp) => {
-                experimental_udp = Some(udp);
-            }
-            Err(e) => {
-                let msg = format!("UDP probe failed: {e:#}");
-                udp_error = Some(msg.clone());
-                event_tx
-                    .send(TestEvent::Info { message: msg })
-                    .await
-                    .ok();
+            {
+                Ok(udp) => {
+                    experimental_udp = Some(udp);
+                }
+                Err(e) => {
+                    let msg = format!("UDP probe failed: {e:#}");
+                    udp_error = Some(msg.clone());
+                    event_tx.send(TestEvent::Info { message: msg }).await.ok();
+                }
             }
         }
 

--- a/src/engine/throughput.rs
+++ b/src/engine/throughput.rs
@@ -51,23 +51,35 @@ fn throughput_summary(bytes: u64, duration: Duration, mbps_samples: &[f64]) -> T
     }
 }
 
-fn estimate_steady_window(
-    samples: &[(Instant, u64)],
+/// Steady-state view of a phase: excludes the ramp-up (the first
+/// `STEADY_STATE_RAMP_FRACTION` of the phase, at least `STEADY_STATE_MIN_RAMP`)
+/// from the byte counters AND the per-tick rate samples, so slow start does
+/// not drag the reported throughput down. `samples[i]` is (active time at
+/// tick i, cumulative bytes at tick i); `mbps_samples[i]` is the rate over
+/// the interval ending at tick i. Returns `None` when there is no usable
+/// steady window (caller falls back to the whole phase).
+fn steady_state_view<'a>(
+    samples: &[(Duration, u64)],
+    mbps_samples: &'a [f64],
     total_duration: Duration,
-) -> Option<(u64, Duration)> {
+) -> Option<(u64, Duration, &'a [f64])> {
     if samples.len() < 2 {
         return None;
     }
-    let ignore = total_duration.mul_f64(0.20).max(Duration::from_secs(1));
-    let t0 = samples[0].0 + ignore;
-    let start_idx = samples.iter().position(|(t, _)| *t >= t0).unwrap_or(0);
+    let ramp = total_duration
+        .mul_f64(crate::constants::STEADY_STATE_RAMP_FRACTION)
+        .max(crate::constants::STEADY_STATE_MIN_RAMP);
+    let start_idx = samples.iter().position(|(t, _)| *t >= ramp)?;
     let (t_start, b_start) = samples[start_idx];
     let (t_end, b_end) = *samples.last().unwrap();
-    let dt = t_end.saturating_duration_since(t_start);
-    if dt < THROUGHPUT_SAMPLE_INTERVAL {
+    let window = t_end.saturating_sub(t_start);
+    if window < THROUGHPUT_SAMPLE_INTERVAL {
         return None;
     }
-    Some((b_end.saturating_sub(b_start), dt))
+    // mbps_samples[i] covers the interval ending at samples[i]; the intervals
+    // fully inside the window start at start_idx + 1.
+    let steady = &mbps_samples[(start_idx + 1).min(mbps_samples.len())..];
+    Some((b_end.saturating_sub(b_start), window, steady))
 }
 
 pub async fn run_download_with_loaded_latency(
@@ -77,6 +89,13 @@ pub async fn run_download_with_loaded_latency(
     paused: Arc<AtomicBool>,
     cancel: Arc<AtomicBool>,
 ) -> Result<(ThroughputSummary, LatencySummary)> {
+    // A cancel that arrived before this phase: don't spawn workers at all.
+    if cancel.load(Ordering::Relaxed) {
+        return Ok((
+            throughput_summary(0, Duration::ZERO, &[]),
+            LatencySummary::failed(),
+        ));
+    }
     let stop = Arc::new(AtomicBool::new(false));
     let total = Arc::new(AtomicU64::new(0));
     let errors = Arc::new(AtomicU64::new(0));
@@ -90,10 +109,17 @@ pub async fn run_download_with_loaded_latency(
         let stop2 = stop.clone();
         let total2 = total.clone();
         let errors2 = errors.clone();
+        let paused_w = paused.clone();
         let ev_dl = event_tx.clone();
 
         handles.push(tokio::spawn(async move {
             while !stop2.load(Ordering::Relaxed) {
+                // Paused means paused: stop pulling bytes so the link is
+                // actually idle, not just unsampled.
+                if paused_w.load(Ordering::Relaxed) {
+                    tokio::time::sleep(crate::constants::PAUSE_POLL_INTERVAL).await;
+                    continue;
+                }
                 let mut url = base_url.clone();
                 url.query_pairs_mut()
                     .append_pair("measId", &meas_id)
@@ -103,6 +129,7 @@ pub async fn run_download_with_loaded_latency(
                     Ok(r) => r,
                     Err(_) => {
                         errors2.fetch_add(1, Ordering::Relaxed);
+                        tokio::time::sleep(crate::constants::WORKER_ERROR_BACKOFF).await;
                         continue;
                     }
                 };
@@ -123,7 +150,7 @@ pub async fn run_download_with_loaded_latency(
                                 .await;
                         }
                     }
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    tokio::time::sleep(crate::constants::WORKER_ERROR_BACKOFF).await;
                     continue;
                 }
 
@@ -131,7 +158,7 @@ pub async fn run_download_with_loaded_latency(
                 while let Some(chunk) = stream.next().await {
                     let Ok(b) = chunk else { break };
                     total2.fetch_add(b.len() as u64, Ordering::Relaxed);
-                    if stop2.load(Ordering::Relaxed) {
+                    if stop2.load(Ordering::Relaxed) || paused_w.load(Ordering::Relaxed) {
                         break;
                     }
                 }
@@ -163,27 +190,35 @@ pub async fn run_download_with_loaded_latency(
         let _ = lat_tx.send(res).await;
     });
 
-    let start = Instant::now();
+    // The phase clock counts ACTIVE time only, so a pause neither eats the
+    // remaining duration nor leaks into any rate sample.
+    let mut active = Duration::ZERO;
     let mut last_bytes = 0u64;
-    let mut last_t = Instant::now();
-    let mut samples: Vec<(Instant, u64)> = Vec::with_capacity(256);
+    let mut samples: Vec<(Duration, u64)> = Vec::with_capacity(256);
     let mut mbps_samples: Vec<f64> = Vec::with_capacity(256);
 
-    while start.elapsed() < cfg.download_duration {
+    while active < cfg.download_duration {
+        let was_paused = paused.load(Ordering::Relaxed);
         if wait_if_paused_or_cancelled(&paused, &cancel).await {
             break;
         }
+        if was_paused {
+            // Just resumed: restart the rate baseline so no sample spans the pause.
+            last_bytes = total.load(Ordering::Relaxed);
+        }
 
+        let tick_start = Instant::now();
         tokio::time::sleep(THROUGHPUT_SAMPLE_INTERVAL).await;
+        let tick_len = tick_start.elapsed();
+        active += tick_len;
 
         let now_total = total.load(Ordering::Relaxed);
-        let dt = last_t.elapsed().as_secs_f64().max(1e-9);
+        let dt = tick_len.as_secs_f64().max(1e-9);
         let dbytes = now_total.saturating_sub(last_bytes);
         let bps_instant = (dbytes as f64) / dt;
         let mbps_instant = (bps_instant * 8.0) / 1_000_000.0;
-        last_t = Instant::now();
         last_bytes = now_total;
-        samples.push((Instant::now(), now_total));
+        samples.push((active, now_total));
         mbps_samples.push(mbps_instant);
 
         event_tx
@@ -201,7 +236,7 @@ pub async fn run_download_with_loaded_latency(
         let _ = h.await;
     }
 
-    let duration = start.elapsed();
+    let duration = active;
     let bytes_total = total.load(Ordering::Relaxed);
     let error_count = errors.load(Ordering::Relaxed);
     if error_count > 0 {
@@ -212,9 +247,9 @@ pub async fn run_download_with_loaded_latency(
             .await
             .ok();
     }
-    let (bytes, window) =
-        estimate_steady_window(&samples, duration).unwrap_or((bytes_total, duration));
-    let dl = throughput_summary(bytes, window, &mbps_samples);
+    let (bytes, window, steady_mbps) = steady_state_view(&samples, &mbps_samples, duration)
+        .unwrap_or((bytes_total, duration, &mbps_samples[..]));
+    let dl = throughput_summary(bytes, window, steady_mbps);
 
     // Wait for latency results with a timeout to prevent indefinite hangs
     let loaded_latency = tokio::time::timeout(Duration::from_secs(30), lat_rx.recv())
@@ -235,6 +270,13 @@ pub async fn run_upload_with_loaded_latency(
     paused: Arc<AtomicBool>,
     cancel: Arc<AtomicBool>,
 ) -> Result<(ThroughputSummary, LatencySummary)> {
+    // A cancel that arrived before this phase: don't spawn workers at all.
+    if cancel.load(Ordering::Relaxed) {
+        return Ok((
+            throughput_summary(0, Duration::ZERO, &[]),
+            LatencySummary::failed(),
+        ));
+    }
     let stop = Arc::new(AtomicBool::new(false));
     let total = Arc::new(AtomicU64::new(0));
     let errors = Arc::new(AtomicU64::new(0));
@@ -247,10 +289,17 @@ pub async fn run_upload_with_loaded_latency(
         let stop2 = stop.clone();
         let total2 = total.clone();
         let errors2 = errors.clone();
+        let paused_w = paused.clone();
         let bytes_per_req = cfg.upload_bytes_per_req;
 
         handles.push(tokio::spawn(async move {
             while !stop2.load(Ordering::Relaxed) {
+                // Paused means paused: stop pushing bytes so the link is
+                // actually idle, not just unsampled.
+                if paused_w.load(Ordering::Relaxed) {
+                    tokio::time::sleep(crate::constants::PAUSE_POLL_INTERVAL).await;
+                    continue;
+                }
                 // Count bytes as the HTTP client pulls chunks from the stream
                 // (backpressure-aware). On failure, subtract what we counted so
                 // the live chart stays smooth without permanently over-reporting.
@@ -284,12 +333,28 @@ pub async fn run_upload_with_loaded_latency(
                 };
 
                 let body = reqwest::Body::wrap_stream(body_stream);
-                match http.post(url.clone()).body(body).send().await {
-                    Ok(resp) if resp.status().is_success() => {}
-                    _ => {
+                // Abort the in-flight request the moment a pause lands, so
+                // "paused" doesn't keep saturating the uplink for a whole body.
+                let pause_hit = async {
+                    while !paused_w.load(Ordering::Relaxed) {
+                        tokio::time::sleep(crate::constants::PAUSE_POLL_INTERVAL).await;
+                    }
+                };
+                tokio::select! {
+                    res = http.post(url.clone()).body(body).send() => {
+                        match res {
+                            Ok(resp) if resp.status().is_success() => {}
+                            _ => {
+                                let rolled_back = counted.load(Ordering::Relaxed);
+                                total2.fetch_sub(rolled_back, Ordering::Relaxed);
+                                errors2.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                    }
+                    _ = pause_hit => {
+                        // Dropped mid-request: those bytes never fully arrived.
                         let rolled_back = counted.load(Ordering::Relaxed);
                         total2.fetch_sub(rolled_back, Ordering::Relaxed);
-                        errors2.fetch_add(1, Ordering::Relaxed);
                     }
                 }
             }
@@ -320,27 +385,33 @@ pub async fn run_upload_with_loaded_latency(
         let _ = lat_tx.send(res).await;
     });
 
-    let start = Instant::now();
+    // Active-time phase clock; see the download loop for the pause semantics.
+    let mut active = Duration::ZERO;
     let mut last_bytes = 0u64;
-    let mut last_t = Instant::now();
-    let mut samples: Vec<(Instant, u64)> = Vec::with_capacity(256);
+    let mut samples: Vec<(Duration, u64)> = Vec::with_capacity(256);
     let mut mbps_samples: Vec<f64> = Vec::with_capacity(256);
 
-    while start.elapsed() < cfg.upload_duration {
+    while active < cfg.upload_duration {
+        let was_paused = paused.load(Ordering::Relaxed);
         if wait_if_paused_or_cancelled(&paused, &cancel).await {
             break;
         }
+        if was_paused {
+            last_bytes = total.load(Ordering::Relaxed);
+        }
 
+        let tick_start = Instant::now();
         tokio::time::sleep(THROUGHPUT_SAMPLE_INTERVAL).await;
+        let tick_len = tick_start.elapsed();
+        active += tick_len;
 
         let now_total = total.load(Ordering::Relaxed);
-        let dt = last_t.elapsed().as_secs_f64().max(1e-9);
+        let dt = tick_len.as_secs_f64().max(1e-9);
         let dbytes = now_total.saturating_sub(last_bytes);
         let bps_instant = (dbytes as f64) / dt;
         let mbps_instant = (bps_instant * 8.0) / 1_000_000.0;
-        last_t = Instant::now();
         last_bytes = now_total;
-        samples.push((Instant::now(), now_total));
+        samples.push((active, now_total));
         mbps_samples.push(mbps_instant);
 
         event_tx
@@ -368,7 +439,7 @@ pub async fn run_upload_with_loaded_latency(
         let _ = h.await;
     }
 
-    let duration = start.elapsed();
+    let duration = active;
     let bytes_total = total.load(Ordering::Relaxed);
     let error_count = errors.load(Ordering::Relaxed);
     if error_count > 0 {
@@ -379,9 +450,9 @@ pub async fn run_upload_with_loaded_latency(
             .await
             .ok();
     }
-    let (bytes, window) =
-        estimate_steady_window(&samples, duration).unwrap_or((bytes_total, duration));
-    let up = throughput_summary(bytes, window, &mbps_samples);
+    let (bytes, window, steady_mbps) = steady_state_view(&samples, &mbps_samples, duration)
+        .unwrap_or((bytes_total, duration, &mbps_samples[..]));
+    let up = throughput_summary(bytes, window, steady_mbps);
 
     // Wait for latency results with a timeout to prevent indefinite hangs
     let loaded_latency = tokio::time::timeout(Duration::from_secs(30), lat_rx.recv())
@@ -393,4 +464,65 @@ pub async fn run_upload_with_loaded_latency(
     let _ = lat_handle.await;
 
     Ok((up, loaded_latency))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secs(s: u64) -> Duration {
+        Duration::from_secs(s)
+    }
+
+    /// Ten 1s ticks: bytes crawl for the first two ticks (ramp), then advance
+    /// a steady 100 bytes/tick. `mbps[i]` is the rate of the interval ending
+    /// at tick i.
+    fn ramp_fixture() -> (Vec<(Duration, u64)>, Vec<f64>) {
+        let bytes = [5u64, 30, 130, 230, 330, 430, 530, 630, 730, 830];
+        let samples: Vec<(Duration, u64)> = bytes
+            .iter()
+            .enumerate()
+            .map(|(i, b)| (secs(i as u64 + 1), *b))
+            .collect();
+        let mut mbps = vec![0.04, 0.2];
+        mbps.extend(std::iter::repeat_n(0.8, 8));
+        (samples, mbps)
+    }
+
+    #[test]
+    fn steady_state_view_excludes_ramp_up() {
+        let (samples, mbps) = ramp_fixture();
+        // 10s phase: ramp = max(20% x 10s, 1s) = 2s, so steady starts at the
+        // first tick at/after t=2s (index 1).
+        let (bytes, window, steady) = steady_state_view(&samples, &mbps, secs(10)).unwrap();
+        assert_eq!(bytes, 830 - 30);
+        assert_eq!(window, secs(8));
+        assert_eq!(steady, &mbps[2..]);
+    }
+
+    #[test]
+    fn steady_state_view_none_when_too_short() {
+        assert!(steady_state_view(&[], &[], secs(10)).is_none());
+        assert!(steady_state_view(&[(secs(1), 100)], &[0.8], secs(1)).is_none());
+        // Every tick still inside the ramp: nothing steady to report.
+        let samples = vec![
+            (Duration::from_millis(200), 10),
+            (Duration::from_millis(400), 20),
+        ];
+        assert!(steady_state_view(&samples, &[0.4, 0.4], secs(10)).is_none());
+    }
+
+    #[test]
+    fn throughput_summary_uses_sample_percentiles() {
+        let s = throughput_summary(1000, secs(1), &[8.0, 8.0, 8.0, 8.0, 8.0]);
+        assert!((s.mbps - 8.0).abs() < 1e-9);
+        assert_eq!(s.bytes, 1000);
+    }
+
+    #[test]
+    fn throughput_summary_falls_back_to_bytes_over_duration() {
+        // 1_000_000 bytes in 1s = 8 Mbps
+        let s = throughput_summary(1_000_000, secs(1), &[]);
+        assert!((s.mbps - 8.0).abs() < 1e-6);
+    }
 }

--- a/src/engine/traceroute.rs
+++ b/src/engine/traceroute.rs
@@ -13,6 +13,8 @@ use std::io::ErrorKind;
 use std::mem::MaybeUninit;
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
@@ -35,14 +37,23 @@ pub async fn run_traceroute(
     bind_ip: Option<IpAddr>,
     interface: Option<&str>,
     family: Option<IpFamily>,
+    cancel: Arc<AtomicBool>,
 ) -> Result<TracerouteSummary> {
     // Resolve destination to IP, honoring the requested family when set.
-    let ip = resolve_destination(destination, family)?;
+    // `to_socket_addrs` blocks, so keep it off the async runtime.
+    let dest = destination.to_string();
+    let ip = tokio::task::spawn_blocking(move || resolve_destination(&dest, family))
+        .await
+        .context("resolve task failed")??;
 
     // Try raw ICMP first
-    match run_icmp_traceroute(&ip, max_hops, event_tx, bind_ip, interface).await {
+    match run_icmp_traceroute(&ip, max_hops, event_tx, bind_ip, interface, cancel.clone()).await {
         Ok(summary) => return Ok(summary),
         Err(e) => {
+            if cancel.load(Ordering::Relaxed) {
+                // Cancelled: don't launch the system tool as a "fallback".
+                return Err(e);
+            }
             // Send info about fallback
             let _ = event_tx
                 .send(TestEvent::Info {
@@ -54,7 +65,16 @@ pub async fn run_traceroute(
 
     // Fall back to system traceroute. `family` is forwarded so a --ipv4-only /
     // --ipv6-only restriction forces the matching family on the system tool.
-    run_system_traceroute(destination, &ip, max_hops, event_tx, bind_ip, interface, family).await
+    run_system_traceroute(
+        destination,
+        &ip,
+        max_hops,
+        event_tx,
+        bind_ip,
+        interface,
+        family,
+    )
+    .await
 }
 
 /// Resolve destination hostname to IP address. When `family` is set, return an
@@ -92,6 +112,7 @@ async fn run_icmp_traceroute(
     event_tx: &mpsc::Sender<TestEvent>,
     bind_ip: Option<IpAddr>,
     interface: Option<&str>,
+    cancel: Arc<AtomicBool>,
 ) -> Result<TracerouteSummary> {
     // Check if we're dealing with IPv4 - IPv6 traceroute is more complex
     let dest_v4 = match destination {
@@ -128,7 +149,11 @@ async fn run_icmp_traceroute(
     // interface's IPv4 source was already bound via `bind_ip` above.
     if let Some(iface) = interface {
         super::network_bind::bind_socket_to_device(&socket, iface, false).map_err(|e| {
-            anyhow::anyhow!("Failed to bind raw ICMP socket to interface {}: {}", iface, e)
+            anyhow::anyhow!(
+                "Failed to bind raw ICMP socket to interface {}: {}",
+                iface,
+                e
+            )
         })?;
     }
 
@@ -137,72 +162,33 @@ async fn run_icmp_traceroute(
 
     let mut hops = Vec::new();
     let mut completed = false;
+    let icmp_id = std::process::id() as u16;
 
+    // Each hop's probe round does blocking sends/recvs (up to PROBES_PER_HOP x
+    // PROBE_TIMEOUT), so it runs on the blocking pool to keep the async
+    // runtime (and the TUI) responsive; the socket travels in and out.
+    let mut sock = socket;
     for ttl in 1..=max_hops {
-        socket.set_ttl(ttl as u32)?;
-
-        let mut rtts = Vec::new();
-        let mut hop_ip: Option<IpAddr> = None;
-        let mut timeout = false;
-
-        for probe_num in 0..PROBES_PER_HOP {
-            let icmp_id = std::process::id() as u16;
-            let icmp_seq = ((ttl as u16) << 8) | (probe_num as u16);
-
-            // Build ICMP echo request packet
-            let packet = build_icmp_packet(icmp_id, icmp_seq);
-
-            let dest_addr = SocketAddr::new(IpAddr::V4(dest_v4), 0);
-
-            let start = Instant::now();
-            if socket.send_to(&packet, &dest_addr.into()).is_err() {
-                continue;
-            }
-
-            // Wait for reply using MaybeUninit buffer
-            let mut recv_buf: [MaybeUninit<u8>; 512] =
-                unsafe { MaybeUninit::uninit().assume_init() };
-            match socket.recv_from(&mut recv_buf) {
-                Ok((len, from)) => {
-                    let rtt = start.elapsed().as_secs_f64() * 1000.0;
-                    rtts.push(rtt);
-
-                    // Extract source IP from reply
-                    let from_addr: SocketAddr = from.as_socket().unwrap_or(dest_addr);
-                    if hop_ip.is_none() {
-                        hop_ip = Some(from_addr.ip());
-                    }
-
-                    // Check if we've reached the destination
-                    if from_addr.ip() == IpAddr::V4(dest_v4) {
-                        completed = true;
-                    }
-
-                    // Check ICMP type to see if we should continue
-                    if len >= 20 + 8 {
-                        // IP header + ICMP header
-                        // Safe to read since we received at least 28 bytes
-                        let icmp_type = unsafe { recv_buf[20].assume_init() };
-                        if icmp_type == IcmpTypes::EchoReply.0 {
-                            completed = true;
-                        }
-                    }
-                }
-                Err(e) if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut => {
-                    timeout = true;
-                }
-                Err(_) => {
-                    timeout = true;
-                }
-            }
+        if cancel.load(Ordering::Relaxed) {
+            break;
         }
+        sock.set_ttl(ttl as u32)?;
+
+        let cancel_hop = cancel.clone();
+        let (sock_back, round) = tokio::task::spawn_blocking(move || {
+            let round = probe_hop(&sock, dest_v4, ttl, icmp_id, &cancel_hop);
+            (sock, round)
+        })
+        .await
+        .context("traceroute probe task failed")?;
+        sock = sock_back;
 
         let hop = TracerouteHop {
             hop_number: ttl,
-            ip_address: hop_ip.map(|ip| ip.to_string()),
-            hostname: hop_ip.and_then(|ip| resolve_hostname(&ip)),
-            rtt_ms: rtts,
-            timeout: timeout && hop_ip.is_none(),
+            ip_address: round.hop_ip.map(|ip| ip.to_string()),
+            hostname: round.hop_ip.and_then(|ip| resolve_hostname(&ip)),
+            rtt_ms: round.rtts,
+            timeout: round.timeout && round.hop_ip.is_none(),
         };
 
         // Send hop event
@@ -215,7 +201,8 @@ async fn run_icmp_traceroute(
 
         hops.push(hop);
 
-        if completed {
+        if round.reached_destination {
+            completed = true;
             break;
         }
     }
@@ -225,6 +212,137 @@ async fn run_icmp_traceroute(
         hops,
         completed,
     })
+}
+
+/// One hop's worth of probes, on a blocking socket.
+struct HopRound {
+    rtts: Vec<f64>,
+    hop_ip: Option<IpAddr>,
+    reached_destination: bool,
+    timeout: bool,
+}
+
+fn probe_hop(
+    socket: &Socket,
+    dest_v4: std::net::Ipv4Addr,
+    ttl: u8,
+    icmp_id: u16,
+    cancel: &AtomicBool,
+) -> HopRound {
+    let dest_addr = SocketAddr::new(IpAddr::V4(dest_v4), 0);
+    let mut rtts = Vec::new();
+    let mut hop_ip: Option<IpAddr> = None;
+    let mut reached_destination = false;
+    let mut timeout = false;
+
+    for probe_num in 0..PROBES_PER_HOP {
+        if cancel.load(Ordering::Relaxed) {
+            break;
+        }
+        let icmp_seq = ((ttl as u16) << 8) | (probe_num as u16);
+        let packet = build_icmp_packet(icmp_id, icmp_seq);
+
+        let start = Instant::now();
+        if socket.send_to(&packet, &dest_addr.into()).is_err() {
+            continue;
+        }
+
+        // Read until this probe's deadline, discarding ICMP traffic that is
+        // not a reply to this exact probe (a raw socket sees everything
+        // ICMP-shaped that reaches the host).
+        let deadline = start + PROBE_TIMEOUT;
+        loop {
+            let now = Instant::now();
+            let remaining = match deadline.checked_duration_since(now) {
+                Some(r) if !r.is_zero() => r,
+                _ => {
+                    timeout = true;
+                    break;
+                }
+            };
+            if socket.set_read_timeout(Some(remaining)).is_err() {
+                timeout = true;
+                break;
+            }
+
+            let mut recv_buf: [MaybeUninit<u8>; 512] =
+                unsafe { MaybeUninit::uninit().assume_init() };
+            match socket.recv_from(&mut recv_buf) {
+                Ok((len, from)) => {
+                    // Safety: recv_from initialized the first `len` bytes.
+                    let data: &[u8] =
+                        unsafe { std::slice::from_raw_parts(recv_buf.as_ptr() as *const u8, len) };
+                    let Some(is_echo_reply) = icmp_reply_matches(data, icmp_id, icmp_seq) else {
+                        continue; // unrelated ICMP packet
+                    };
+
+                    rtts.push(start.elapsed().as_secs_f64() * 1000.0);
+
+                    let from_addr: SocketAddr = from.as_socket().unwrap_or(dest_addr);
+                    if hop_ip.is_none() {
+                        hop_ip = Some(from_addr.ip());
+                    }
+                    if is_echo_reply || from_addr.ip() == IpAddr::V4(dest_v4) {
+                        reached_destination = true;
+                    }
+                    break;
+                }
+                Err(e) if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut => {
+                    timeout = true;
+                    break;
+                }
+                Err(_) => {
+                    timeout = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    HopRound {
+        rtts,
+        hop_ip,
+        reached_destination,
+        timeout,
+    }
+}
+
+/// Classify a raw IPv4 datagram as a reply to OUR probe (`id`, `seq`).
+/// A raw ICMP socket receives every ICMP packet addressed to the host, so
+/// anything that does not carry our id/seq (directly in an EchoReply, or
+/// embedded in a TimeExceeded / DestinationUnreachable) must be ignored.
+/// Returns `None` for unrelated packets, `Some(true)` for an EchoReply from
+/// the destination (path complete), `Some(false)` for a hop reply.
+fn icmp_reply_matches(packet: &[u8], id: u16, seq: u16) -> Option<bool> {
+    fn be16(b: &[u8], i: usize) -> Option<u16> {
+        Some(u16::from_be_bytes([*b.get(i)?, *b.get(i + 1)?]))
+    }
+
+    let ihl = ((*packet.first()? & 0x0f) as usize) * 4;
+    if ihl < 20 {
+        return None;
+    }
+    let icmp = packet.get(ihl..)?;
+    let ty = *icmp.first()?;
+
+    if ty == IcmpTypes::EchoReply.0 {
+        return (be16(icmp, 4)? == id && be16(icmp, 6)? == seq).then_some(true);
+    }
+    if ty == IcmpTypes::TimeExceeded.0 || ty == IcmpTypes::DestinationUnreachable.0 {
+        // The embedded original datagram starts after the 8-byte ICMP header:
+        // its own IP header, then the first 8 bytes of our echo request.
+        let inner_ip = icmp.get(8..)?;
+        let inner_ihl = ((*inner_ip.first()? & 0x0f) as usize) * 4;
+        if inner_ihl < 20 {
+            return None;
+        }
+        let inner_icmp = inner_ip.get(inner_ihl..)?;
+        if *inner_icmp.first()? != IcmpTypes::EchoRequest.0 {
+            return None;
+        }
+        return (be16(inner_icmp, 4)? == id && be16(inner_icmp, 6)? == seq).then_some(false);
+    }
+    None
 }
 
 /// Build an ICMP echo request packet.
@@ -242,8 +360,8 @@ fn build_icmp_packet(id: u16, seq: u16) -> Vec<u8> {
     packet[7] = (seq & 0xff) as u8;
 
     // Payload (timestamp and padding)
-    for i in 8..64 {
-        packet[i] = (i - 8) as u8;
+    for (i, byte) in packet[8..64].iter_mut().enumerate() {
+        *byte = i as u8;
     }
 
     // Calculate checksum
@@ -513,6 +631,76 @@ fn parse_hop_line(line: &str) -> Option<TracerouteHop> {
 mod tests {
     use super::*;
 
+    /// Raw IPv4 datagram: header of `ihl_words` 32-bit words, then `payload`.
+    fn ipv4_packet(ihl_words: u8, payload: &[u8]) -> Vec<u8> {
+        let mut p = vec![0u8; ihl_words as usize * 4];
+        p[0] = 0x40 | ihl_words;
+        p.extend_from_slice(payload);
+        p
+    }
+
+    fn echo_reply(id: u16, seq: u16) -> Vec<u8> {
+        let mut icmp = vec![0u8; 8];
+        icmp[0] = IcmpTypes::EchoReply.0;
+        icmp[4..6].copy_from_slice(&id.to_be_bytes());
+        icmp[6..8].copy_from_slice(&seq.to_be_bytes());
+        icmp
+    }
+
+    /// TimeExceeded embedding the original echo request with `id`/`seq`.
+    fn time_exceeded(id: u16, seq: u16) -> Vec<u8> {
+        let mut icmp = vec![0u8; 8];
+        icmp[0] = IcmpTypes::TimeExceeded.0;
+        let mut inner_ip = vec![0u8; 20];
+        inner_ip[0] = 0x45;
+        icmp.extend_from_slice(&inner_ip);
+        let mut inner_icmp = vec![0u8; 8];
+        inner_icmp[0] = IcmpTypes::EchoRequest.0;
+        inner_icmp[4..6].copy_from_slice(&id.to_be_bytes());
+        inner_icmp[6..8].copy_from_slice(&seq.to_be_bytes());
+        icmp.extend_from_slice(&inner_icmp);
+        icmp
+    }
+
+    #[test]
+    fn accepts_matching_echo_reply() {
+        let pkt = ipv4_packet(5, &echo_reply(42, 7));
+        assert_eq!(icmp_reply_matches(&pkt, 42, 7), Some(true));
+    }
+
+    #[test]
+    fn accepts_matching_time_exceeded_hop_reply() {
+        let pkt = ipv4_packet(5, &time_exceeded(42, 7));
+        assert_eq!(icmp_reply_matches(&pkt, 42, 7), Some(false));
+    }
+
+    #[test]
+    fn rejects_echo_reply_for_another_process() {
+        let pkt = ipv4_packet(5, &echo_reply(9999, 7));
+        assert_eq!(icmp_reply_matches(&pkt, 42, 7), None);
+    }
+
+    #[test]
+    fn rejects_time_exceeded_for_another_probe() {
+        // Same id (our process) but a different probe's seq: this run's own
+        // late reply from a previous TTL must not be credited to this hop.
+        let pkt = ipv4_packet(5, &time_exceeded(42, 3));
+        assert_eq!(icmp_reply_matches(&pkt, 42, 7), None);
+    }
+
+    #[test]
+    fn handles_ip_header_with_options() {
+        // IHL = 6 words (one option word): the ICMP header is NOT at byte 20.
+        let pkt = ipv4_packet(6, &echo_reply(42, 7));
+        assert_eq!(icmp_reply_matches(&pkt, 42, 7), Some(true));
+    }
+
+    #[test]
+    fn rejects_truncated_packet() {
+        assert_eq!(icmp_reply_matches(&[0x45, 0, 0], 42, 7), None);
+        assert_eq!(icmp_reply_matches(&[], 42, 7), None);
+    }
+
     #[test]
     fn parses_linux_with_hostname() {
         let line = " 1  host.example.com (1.2.3.4)  0.5 ms  0.4 ms  0.6 ms";
@@ -539,7 +727,10 @@ mod tests {
         let line = " 3  10.0.0.1 (10.0.0.1)  5.2 ms 4.8 ms 5.1 ms";
         let hop = parse_hop_line(line).unwrap();
         assert_eq!(hop.ip_address.as_deref(), Some("10.0.0.1"));
-        assert_eq!(hop.hostname, None, "hostname should be elided when same as ip");
+        assert_eq!(
+            hop.hostname, None,
+            "hostname should be elided when same as ip"
+        );
     }
 
     #[test]
@@ -564,7 +755,8 @@ mod tests {
     #[test]
     fn first_ip_wins_on_multi_router_hop() {
         // Some hops have two routers responding; we keep the first IP/hostname pair.
-        let line = " 5  a.example.com (1.1.1.1)  260.2 ms b.example.com (2.2.2.2)  260.1 ms 260.0 ms";
+        let line =
+            " 5  a.example.com (1.1.1.1)  260.2 ms b.example.com (2.2.2.2)  260.1 ms 260.0 ms";
         let hop = parse_hop_line(line).unwrap();
         assert_eq!(hop.ip_address.as_deref(), Some("1.1.1.1"));
         assert_eq!(hop.hostname.as_deref(), Some("a.example.com"));

--- a/src/engine/turn_udp.rs
+++ b/src/engine/turn_udp.rs
@@ -5,7 +5,8 @@ use anyhow::{anyhow, Context, Result};
 use rand::RngCore;
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 
@@ -81,19 +82,23 @@ fn build_stun_binding_request(txid: [u8; 12]) -> [u8; 20] {
     b
 }
 
-fn is_stun_binding_response(buf: &[u8], txid: [u8; 12]) -> bool {
+/// When `buf` is a STUN binding success response whose transaction id belongs
+/// to a probe we sent, returns that probe's sequence number.
+fn match_binding_response(buf: &[u8], txid_to_seq: &HashMap<[u8; 12], u64>) -> Option<u64> {
     if buf.len() < 20 {
-        return false;
+        return None;
     }
     // binding success response
     if buf[0] != 0x01 || buf[1] != 0x01 {
-        return false;
+        return None;
     }
     // magic cookie
     if buf[4] != 0x21 || buf[5] != 0x12 || buf[6] != 0xA4 || buf[7] != 0x42 {
-        return false;
+        return None;
     }
-    buf[8..20] == txid
+    let mut txid = [0u8; 12];
+    txid.copy_from_slice(&buf[8..20]);
+    txid_to_seq.get(&txid).copied()
 }
 
 fn pick_stun_target(turn: &TurnInfo) -> Option<String> {
@@ -135,12 +140,39 @@ fn parse_host_port(url: &str) -> Result<(String, u16)> {
     Ok((host.to_string(), port))
 }
 
+/// Tracks probe-response arrivals for the loss/reorder metrics: dedupes
+/// duplicate responses per sequence number and counts an arrival as
+/// out-of-order when an earlier-sequenced probe lands after a
+/// later-sequenced one already has.
+#[derive(Default)]
+struct ArrivalTracker {
+    arrived: std::collections::HashSet<u64>,
+    max_arrived_seq: u64,
+    out_of_order: u64,
+}
+
+impl ArrivalTracker {
+    /// Records an arrival; returns false for duplicates.
+    fn record(&mut self, seq: u64) -> bool {
+        if !self.arrived.insert(seq) {
+            return false;
+        }
+        if seq < self.max_arrived_seq {
+            self.out_of_order += 1;
+        } else {
+            self.max_arrived_seq = seq;
+        }
+        true
+    }
+}
+
 pub async fn run_udp_like_loss_probe(
     turn: &TurnInfo,
     cfg: &RunConfig,
     event_tx: &mpsc::Sender<TestEvent>,
     pre_resolved: Vec<SocketAddr>,
     family: Option<IpFamily>,
+    cancel: &AtomicBool,
 ) -> Result<ExperimentalUdpSummary> {
     let target_url = pick_stun_target(turn).context("no stun/turn url in /__turn")?;
     let (host, port) = parse_host_port(&target_url)?;
@@ -163,7 +195,11 @@ pub async fn run_udp_like_loss_probe(
     // a UDP socket bound to a v4 source can't connect() to a v6 peer
     // (EAFNOSUPPORT) and vice versa.
     let candidates: Vec<SocketAddr> = match family {
-        Some(f) => resolved.iter().copied().filter(|a| f.matches(a.ip())).collect(),
+        Some(f) => resolved
+            .iter()
+            .copied()
+            .filter(|a| f.matches(a.ip()))
+            .collect(),
         None => resolved,
     };
 
@@ -177,8 +213,8 @@ pub async fn run_udp_like_loss_probe(
 
     let (sock, _addr) = bind_and_connect_udp(&candidates, cfg).await?;
 
-    let timeout = Duration::from_millis(600);
-    let interval = Duration::from_millis(80);
+    let timeout = crate::constants::UDP_PROBE_TIMEOUT;
+    let interval = crate::constants::UDP_PROBE_INTERVAL;
     let attempts = cfg.udp_packets;
 
     let mut sent = 0u64;
@@ -186,12 +222,14 @@ pub async fn run_udp_like_loss_probe(
     let mut samples = Vec::<f64>::new();
     let mut online = OnlineStats::default();
 
-    // Out-of-order tracking: map transaction ID to sequence number
     let mut txid_to_seq: HashMap<[u8; 12], u64> = HashMap::new();
-    let mut next_expected_seq: u64 = 1;
-    let mut out_of_order: u64 = 0;
+    let mut send_times: HashMap<u64, Instant> = HashMap::new();
+    let mut tracker = ArrivalTracker::default();
 
     for seq in 1..=attempts {
+        if cancel.load(Ordering::Relaxed) {
+            break;
+        }
         sent += 1;
 
         let mut txid = [0u8; 12];
@@ -199,54 +237,74 @@ pub async fn run_udp_like_loss_probe(
         txid_to_seq.insert(txid, seq);
         let pkt = build_stun_binding_request(txid);
 
-        let start = std::time::Instant::now();
+        let start = Instant::now();
+        send_times.insert(seq, start);
         let _ = sock.send(&pkt).await;
 
+        // Read until this probe's deadline. A delayed response to an EARLIER
+        // probe must not consume this slot (that would record two losses for
+        // one late packet): credit it to its own sequence and keep waiting.
+        let deadline = start + timeout;
+        let mut got_current = false;
         let mut buf = [0u8; 1500];
-        let recv = tokio::time::timeout(timeout, sock.recv(&mut buf)).await;
-        match recv {
-            Ok(Ok(n)) if is_stun_binding_response(&buf[..n], txid) => {
-                received += 1;
-                let ms = start.elapsed().as_secs_f64() * 1000.0;
-                samples.push(ms);
-                online.push(ms);
-
-                // Check for out-of-order: if this packet's seq < expected, it's reordered
-                if let Some(&pkt_seq) = txid_to_seq.get(&txid) {
-                    if pkt_seq < next_expected_seq {
-                        out_of_order += 1;
-                    } else {
-                        // Update expected to next after this one
-                        next_expected_seq = pkt_seq + 1;
+        loop {
+            let now = Instant::now();
+            let Some(remaining) = deadline.checked_duration_since(now) else {
+                break;
+            };
+            match tokio::time::timeout(remaining, sock.recv(&mut buf)).await {
+                Ok(Ok(n)) => {
+                    let Some(rx_seq) = match_binding_response(&buf[..n], &txid_to_seq) else {
+                        continue; // unrelated datagram
+                    };
+                    if !tracker.record(rx_seq) {
+                        continue; // duplicate response
+                    }
+                    received += 1;
+                    let rtt_ms = send_times
+                        .get(&rx_seq)
+                        .map(|t0| t0.elapsed().as_secs_f64() * 1000.0);
+                    if let Some(ms) = rtt_ms {
+                        samples.push(ms);
+                        online.push(ms);
+                    }
+                    if rx_seq == seq {
+                        got_current = true;
+                    }
+                    event_tx
+                        .send(TestEvent::UdpLossProgress {
+                            sent,
+                            received,
+                            total: attempts,
+                            rtt_ms,
+                        })
+                        .await
+                        .ok();
+                    if got_current {
+                        break;
                     }
                 }
+                // Socket error or deadline elapsed.
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
 
-                event_tx
-                    .send(TestEvent::UdpLossProgress {
-                        sent,
-                        received,
-                        total: attempts,
-                        rtt_ms: Some(ms),
-                    })
-                    .await
-                    .ok();
-            }
-            _ => {
-                // loss/timeout
-                event_tx
-                    .send(TestEvent::UdpLossProgress {
-                        sent,
-                        received,
-                        total: attempts,
-                        rtt_ms: None,
-                    })
-                    .await
-                    .ok();
-            }
+        if !got_current {
+            event_tx
+                .send(TestEvent::UdpLossProgress {
+                    sent,
+                    received,
+                    total: attempts,
+                    rtt_ms: None,
+                })
+                .await
+                .ok();
         }
 
         tokio::time::sleep(interval).await;
     }
+
+    let out_of_order = tracker.out_of_order;
 
     let latency = latency_summary_from_samples(sent, received, &samples, online.stddev());
 
@@ -334,7 +392,11 @@ fn build_udp_socket(
         socket.bind(&socket2::SockAddr::from(addr))?;
         socket.into()
     } else {
-        let any = if target.is_ipv4() { "0.0.0.0:0" } else { "[::]:0" };
+        let any = if target.is_ipv4() {
+            "0.0.0.0:0"
+        } else {
+            "[::]:0"
+        };
         std::net::UdpSocket::bind(any)?
     };
 
@@ -370,5 +432,31 @@ mod tests {
     fn calculate_mos_rejects_invalid_inputs() {
         assert!(calculate_mos(f64::NAN, 1.0, 0.0).is_none());
         assert!(calculate_mos(-1.0, 1.0, 0.0).is_none());
+    }
+
+    #[test]
+    fn arrival_tracker_in_order_arrivals_are_not_reordered() {
+        let mut t = ArrivalTracker::default();
+        assert!(t.record(1));
+        assert!(t.record(2));
+        assert!(t.record(3));
+        assert_eq!(t.out_of_order, 0);
+    }
+
+    #[test]
+    fn arrival_tracker_counts_reordered_arrival() {
+        let mut t = ArrivalTracker::default();
+        t.record(1);
+        t.record(3);
+        t.record(2); // lands after 3 already arrived: reordered
+        assert_eq!(t.out_of_order, 1);
+    }
+
+    #[test]
+    fn arrival_tracker_ignores_duplicate_responses() {
+        let mut t = ArrivalTracker::default();
+        assert!(t.record(1));
+        assert!(!t.record(1));
+        assert_eq!(t.out_of_order, 0);
     }
 }

--- a/src/quality.rs
+++ b/src/quality.rs
@@ -1,7 +1,10 @@
 //! Pure functions that turn measured numbers into Connection Quality grades.
 //! No I/O, no global state. See docs/superpowers/specs/2026-05-24-connection-quality-design.md.
 
-use crate::constants::{BUFFERBLOAT_THRESHOLDS, GRADE_UNAVAILABLE, MIN_STABILITY_SAMPLES, STABILITY_THRESHOLDS};
+use crate::constants::{
+    BUFFERBLOAT_THRESHOLDS, GRADE_UNAVAILABLE, MIN_STABILITY_SAMPLES, STABILITY_THRESHOLDS,
+    STEADY_STATE_MIN_RAMP, STEADY_STATE_RAMP_FRACTION,
+};
 use crate::model::{ConnectionQuality, RunResult};
 
 /// Map a latency-increase-under-load value (ms) to a Waveform grade.
@@ -44,6 +47,23 @@ pub fn cv_percent(samples: &[f64]) -> Option<f64> {
     Some(var.sqrt() / mean * 100.0)
 }
 
+/// Drops the ramp-up prefix from a throughput point series `(t_secs, mbps)`:
+/// everything within max(`STEADY_STATE_RAMP_FRACTION` x span,
+/// `STEADY_STATE_MIN_RAMP`) of the first point, so TCP slow start does not
+/// read as instability.
+fn steady_points(points: &[(f64, f64)]) -> &[(f64, f64)] {
+    let (Some((t_first, _)), Some((t_last, _))) = (points.first(), points.last()) else {
+        return points;
+    };
+    let span = t_last - t_first;
+    let cutoff =
+        t_first + (span * STEADY_STATE_RAMP_FRACTION).max(STEADY_STATE_MIN_RAMP.as_secs_f64());
+    match points.iter().position(|(t, _)| *t >= cutoff) {
+        Some(i) => &points[i..],
+        None => &[],
+    }
+}
+
 /// Build `ConnectionQuality` from a finished `RunResult` and the per-second
 /// throughput sample vectors recorded during the run. Returns `None` only if
 /// neither bufferbloat nor stability can be computed.
@@ -73,9 +93,9 @@ pub fn compute(
         None => None,
     };
 
-    // Stability: worst-of available directions.
-    let dl_mbps: Vec<f64> = dl_points.iter().map(|(_, m)| *m).collect();
-    let ul_mbps: Vec<f64> = ul_points.iter().map(|(_, m)| *m).collect();
+    // Stability: worst-of available directions, over steady-state samples only.
+    let dl_mbps: Vec<f64> = steady_points(dl_points).iter().map(|(_, m)| *m).collect();
+    let ul_mbps: Vec<f64> = steady_points(ul_points).iter().map(|(_, m)| *m).collect();
     let cv_dl = cv_percent(&dl_mbps);
     let cv_ul = cv_percent(&ul_mbps);
     let cv_worst = match (cv_dl, cv_ul) {
@@ -114,14 +134,26 @@ mod tests {
 
     fn make_result(idle_med: Option<f64>, dl_med: Option<f64>, ul_med: Option<f64>) -> RunResult {
         let mut r = empty_run_result();
-        r.idle_latency = LatencySummary { median_ms: idle_med, ..Default::default() };
-        r.loaded_latency_download = LatencySummary { median_ms: dl_med, ..Default::default() };
-        r.loaded_latency_upload = LatencySummary { median_ms: ul_med, ..Default::default() };
+        r.idle_latency = LatencySummary {
+            median_ms: idle_med,
+            ..Default::default()
+        };
+        r.loaded_latency_download = LatencySummary {
+            median_ms: dl_med,
+            ..Default::default()
+        };
+        r.loaded_latency_upload = LatencySummary {
+            median_ms: ul_med,
+            ..Default::default()
+        };
         r
     }
 
     fn pts(mbps: &[f64]) -> Vec<(f64, f64)> {
-        mbps.iter().enumerate().map(|(i, m)| (i as f64, *m)).collect()
+        mbps.iter()
+            .enumerate()
+            .map(|(i, m)| (i as f64, *m))
+            .collect()
     }
 
     #[test]
@@ -158,7 +190,12 @@ mod tests {
         // Worst = 30ms = A.
         let r = make_result(Some(20.0), Some(25.0), Some(50.0));
         // Steady ~100Mbps download, ~8.5% CV upload (mean 98, stddev ~8.37).
-        let cq = compute(&r, &pts(&[100.0; 5]), &pts(&[90.0, 100.0, 110.0, 100.0, 90.0])).unwrap();
+        let cq = compute(
+            &r,
+            &pts(&[100.0; 5]),
+            &pts(&[90.0, 100.0, 110.0, 100.0, 90.0]),
+        )
+        .unwrap();
         assert_eq!(cq.bufferbloat_grade, "A");
         assert!((cq.bufferbloat_ms.unwrap() - 30.0).abs() < 0.01);
         assert!(cq.stability_cv_download_pct.unwrap() < 0.01);
@@ -166,6 +203,17 @@ mod tests {
         // Worst-of stability: upload wins.
         assert!((cq.stability_cv_pct.unwrap() - cq.stability_cv_upload_pct.unwrap()).abs() < 0.01);
         assert_eq!(cq.stability_grade, "B");
+    }
+
+    #[test]
+    fn stability_ignores_ramp_up_prefix() {
+        let r = make_result(None, Some(100.0), Some(100.0));
+        // 10 per-second points: TCP ramp for the first 2s, rock-steady after.
+        // A stable link must not be graded down for its slow start.
+        let mut points = vec![(0.0, 5.0), (1.0, 50.0)];
+        points.extend((2..10).map(|i| (i as f64, 100.0)));
+        let cq = compute(&r, &points, &points).unwrap();
+        assert_eq!(cq.stability_grade, "A", "cv={:?}", cq.stability_cv_pct);
     }
 
     #[test]


### PR DESCRIPTION
- The steady-state window was computed but never applied: the headline Mbps averaged in TCP slow start, biasing results low. `steady_state_view` now trims the ramp-up (first 20% of the phase, at least 1s) from both the byte counters and the percentile samples, and the stability grade's CV gets the same trim so a stable link is not penalized for its ramp.
- Pause now actually pauses: workers stop pulling/pushing bytes (upload aborts the in-flight request), and the phase clock counts active time only, so paused time neither eats the remaining duration nor pollutes rate samples.
- Cancel is honored everywhere: diagnostics, IP comparison, traceroute, and the UDP probe all check the cancel flag, so cancelling or rerunning from the TUI responds in milliseconds instead of freezing until the phase finishes.
- UDP loss probe: reads until each probe's deadline, discards unrelated datagrams, and credits a late response to its own probe instead of recording two losses for one delayed packet. The out-of-order metric was provably always 0; it now measures real reordering.
- ICMP traceroute: replies are validated against our id/seq (a raw socket sees every ICMP packet on the host, so other processes' pings were being recorded as hops), IP header options are handled, and the blocking socket I/O runs on the blocking pool instead of stalling the async runtime.
- IPv4-vs-IPv6 comparison: latency is now the median of several warm-connection probes instead of one cold connect+TLS handshake (~3x the real RTT), and download/upload only count bytes on 2xx responses.