### PR TITLE
Add CI workflow with SHA-pinned actions and fix all clippy and fmt warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  lint:
+    name: fmt + clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+        with:
+          toolchain: stable
+          components: clippy,rustfmt
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all-features --all-targets -- -D warnings
+
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo test --all-features
+
+  # The test suite assumes Unix loopback interface names (lo/lo0), so Windows
+  # is compile-checked only until the suite is validated on Windows runners.
+  build-windows:
+    name: build (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo build --all-features

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # cloudflare-speed-cli
 
+[![CI](https://github.com/kavehtehrani/cloudflare-speed-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/kavehtehrani/cloudflare-speed-cli/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/cloudflare-speed-cli.svg)](https://crates.io/crates/cloudflare-speed-cli)
 [![Rust](https://img.shields.io/badge/rust-1.81+-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)

--- a/src/engine/cert.rs
+++ b/src/engine/cert.rs
@@ -108,10 +108,7 @@ fn parse_pem_certificates(input: &str) -> Result<Vec<Vec<u8>>> {
             body.push_str(trimmed);
         }
         if !found_end {
-            return Err(anyhow::anyhow!(
-                "PEM block missing '{}' marker",
-                END
-            ));
+            return Err(anyhow::anyhow!("PEM block missing '{}' marker", END));
         }
 
         let der = base64::engine::general_purpose::STANDARD
@@ -121,10 +118,7 @@ fn parse_pem_certificates(input: &str) -> Result<Vec<Vec<u8>>> {
     }
 
     if certs.is_empty() {
-        return Err(anyhow::anyhow!(
-            "no '{}' blocks found in PEM input",
-            BEGIN
-        ));
+        return Err(anyhow::anyhow!("no '{}' blocks found in PEM input", BEGIN));
     }
 
     Ok(certs)

--- a/src/engine/cloudflare.rs
+++ b/src/engine/cloudflare.rs
@@ -97,7 +97,6 @@ impl CloudflareClient {
         self.base_url.join("/__up").expect("join __up")
     }
 
-
     pub async fn probe_latency_ms(
         &self,
         during: Option<&str>,

--- a/src/engine/dns.rs
+++ b/src/engine/dns.rs
@@ -248,14 +248,30 @@ pub async fn fetch_external_ips(
     let (ipv4, ipv6) = tokio::join!(
         async {
             if want_v4 {
-                fetch_external_ip_version(&url, &hostname, IpVersion::V4, interface, bind_ip, cert_path).await
+                fetch_external_ip_version(
+                    &url,
+                    &hostname,
+                    IpVersion::V4,
+                    interface,
+                    bind_ip,
+                    cert_path,
+                )
+                .await
             } else {
                 None
             }
         },
         async {
             if want_v6 {
-                fetch_external_ip_version(&url, &hostname, IpVersion::V6, interface, bind_ip, cert_path).await
+                fetch_external_ip_version(
+                    &url,
+                    &hostname,
+                    IpVersion::V6,
+                    interface,
+                    bind_ip,
+                    cert_path,
+                )
+                .await
             } else {
                 None
             }

--- a/src/engine/latency.rs
+++ b/src/engine/latency.rs
@@ -7,6 +7,7 @@ use std::sync::{atomic::AtomicBool, Arc};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_latency_probes(
     client: &CloudflareClient,
     phase: Phase,

--- a/src/engine/network_bind.rs
+++ b/src/engine/network_bind.rs
@@ -95,7 +95,6 @@ pub async fn resolve_addrs_for_family(
     Ok(addrs)
 }
 
-
 /// Apply local address binding to a reqwest client builder.
 /// If `bind_ip` is Some, binds the client to that local address.
 pub fn apply_local_address(builder: ClientBuilder, bind_ip: Option<IpAddr>) -> ClientBuilder {
@@ -374,7 +373,12 @@ mod tests {
             Some(v4)
         );
         assert_eq!(
-            select_source_ip(Some(IpFamily::V6), Some(v4), Some(global_v6), Some(link_local)),
+            select_source_ip(
+                Some(IpFamily::V6),
+                Some(v4),
+                Some(global_v6),
+                Some(link_local)
+            ),
             Some(global_v6)
         );
     }

--- a/src/engine/tls.rs
+++ b/src/engine/tls.rs
@@ -82,10 +82,13 @@ pub async fn measure_tls_handshake(
 
     // Time only the TLS handshake
     let start = Instant::now();
-    let tls_stream = timeout(HANDSHAKE_TIMEOUT, connector.connect(server_name, tcp_stream))
-        .await
-        .with_context(|| format!("TLS handshake timed out after {:?}", HANDSHAKE_TIMEOUT))?
-        .with_context(|| format!("TLS handshake failed with {}", hostname))?;
+    let tls_stream = timeout(
+        HANDSHAKE_TIMEOUT,
+        connector.connect(server_name, tcp_stream),
+    )
+    .await
+    .with_context(|| format!("TLS handshake timed out after {:?}", HANDSHAKE_TIMEOUT))?
+    .with_context(|| format!("TLS handshake failed with {}", hostname))?;
     let handshake_time = start.elapsed();
 
     // Extract TLS session info
@@ -128,7 +131,11 @@ async fn connect_tcp(
     // Filter by the requested family if set; otherwise try all. `family`
     // already incorporates the bind IP's family, so binding stays consistent.
     let candidates: Vec<SocketAddr> = match family {
-        Some(f) => resolved.iter().copied().filter(|a| f.matches(a.ip())).collect(),
+        Some(f) => resolved
+            .iter()
+            .copied()
+            .filter(|a| f.matches(a.ip()))
+            .collect(),
         None => resolved.clone(),
     };
 
@@ -165,7 +172,8 @@ async fn connect_tcp(
         // source per family); elsewhere the interface was already resolved to
         // `bind_ip` above, so this is a no-op.
         if let Some(iface) = interface {
-            if let Err(e) = super::network_bind::bind_socket_to_device(&socket, iface, addr.is_ipv6())
+            if let Err(e) =
+                super::network_bind::bind_socket_to_device(&socket, iface, addr.is_ipv6())
             {
                 last_err =
                     Some(anyhow!(e).context(format!("failed to bind to interface {}", iface)));
@@ -175,7 +183,9 @@ async fn connect_tcp(
 
         match timeout(CONNECT_TIMEOUT, socket.connect(addr)).await {
             Ok(Ok(stream)) => return Ok(stream),
-            Ok(Err(e)) => last_err = Some(anyhow!(e).context(format!("connect to {} failed", addr))),
+            Ok(Err(e)) => {
+                last_err = Some(anyhow!(e).context(format!("connect to {} failed", addr)))
+            }
             Err(_) => {
                 last_err = Some(anyhow!(
                     "connect to {} timed out after {:?}",

--- a/src/event_format.rs
+++ b/src/event_format.rs
@@ -256,7 +256,10 @@ pub fn format_result_summary(
 
     if let Some(ref cq) = result.connection_quality {
         if let Some(ms) = cq.bufferbloat_ms {
-            out.push(format!("Bufferbloat: {} ({:.0}ms)", cq.bufferbloat_grade, ms));
+            out.push(format!(
+                "Bufferbloat: {} ({:.0}ms)",
+                cq.bufferbloat_grade, ms
+            ));
         }
         if let Some(cv) = cq.stability_cv_pct {
             let mut detail = format!("CV {:.1}%", cv);
@@ -299,7 +302,9 @@ mod tests {
         });
         let out = format_result_summary(&r, &[], &[], &[], &[], &[]);
         assert!(out.iter().any(|l| l == "Bufferbloat: B (47ms)"));
-        assert!(out.iter().any(|l| l == "Stability: A (CV 3.8%, DL 3.1%, UL 3.8%)"));
+        assert!(out
+            .iter()
+            .any(|l| l == "Stability: A (CV 3.8%, DL 3.1%, UL 3.8%)"));
     }
 
     #[test]

--- a/src/network.rs
+++ b/src/network.rs
@@ -67,9 +67,9 @@ pub struct NetworkInfo {
 pub fn gather_network_info(args: &Cli) -> NetworkInfo {
     // Determine the interface: explicit --interface, reverse-lookup from --source, or auto-detect
     let resolved_iface = args.interface.clone().or_else(|| {
-        args.source.as_ref().and_then(|ip| {
-            crate::engine::network_bind::get_interface_for_ip(ip)
-        })
+        args.source
+            .as_ref()
+            .and_then(|ip| crate::engine::network_bind::get_interface_for_ip(ip))
     });
 
     let (interface_name, network_name, is_wireless, interface_mac) =
@@ -213,8 +213,7 @@ fn parse_default_iface_from_netstat_json(json: &str, family: Option<IpFamily>) -
         None => matches!(af, Some("Internet" | "Internet6")),
     };
 
-    let families =
-        v["statistics"]["route-information"]["route-table"]["rt-family"].as_array()?;
+    let families = v["statistics"]["route-information"]["route-table"]["rt-family"].as_array()?;
 
     for family_entry in families {
         if af_matches(family_entry["address-family"].as_str()) {
@@ -379,9 +378,7 @@ fn check_if_wireless(iface: &str) -> Option<bool> {
         .ok()?;
     let output_str = String::from_utf8(output.stdout).ok()?;
 
-    let is_wireless = output_str
-        .lines()
-        .any(|line| line.trim() == iface);
+    let is_wireless = output_str.lines().any(|line| line.trim() == iface);
 
     Some(is_wireless)
 }
@@ -417,7 +414,12 @@ fn check_if_wireless(iface: &str) -> Option<bool> {
     for line in output_str.lines() {
         let line = line.trim();
         if line.starts_with("Hardware Port:") {
-            let port_name = line.splitn(2, ':').nth(1).unwrap_or("").trim().to_lowercase();
+            let port_name = line
+                .splitn(2, ':')
+                .nth(1)
+                .unwrap_or("")
+                .trim()
+                .to_lowercase();
             is_wifi_section = port_name.contains("wi-fi") || port_name.contains("airport");
         } else if line.starts_with("Device:") {
             if let Some(device) = line.splitn(2, ':').nth(1) {
@@ -460,7 +462,7 @@ fn get_wireless_ssid(iface: &str) -> Option<String> {
     }
 
     // Fallback: try iw command
-    if let Ok(output) = Command::new("iw").args(&["dev", iface, "info"]).output() {
+    if let Ok(output) = Command::new("iw").args(["dev", iface, "info"]).output() {
         if let Ok(output_str) = String::from_utf8(output.stdout) {
             for line in output_str.lines() {
                 if line.trim().starts_with("ssid ") {
@@ -478,10 +480,7 @@ fn get_wireless_ssid(iface: &str) -> Option<String> {
 
 #[cfg(target_os = "freebsd")]
 fn get_wireless_ssid(iface: &str) -> Option<String> {
-    let output = Command::new("ifconfig")
-        .arg(iface)
-        .output()
-        .ok()?;
+    let output = Command::new("ifconfig").arg(iface).output().ok()?;
 
     if !output.status.success() {
         return None;
@@ -725,10 +724,8 @@ fn get_interface_ips(interface_name: Option<&str>) -> (Option<String>, Option<St
             if_addrs::IfAddr::V6(ref addr) => {
                 // Skip link-local addresses (fe80::)
                 let ip = addr.ip;
-                if !ip.is_loopback() && !is_link_local_v6(&ip) {
-                    if ipv6.is_none() {
-                        ipv6 = Some(ip.to_string());
-                    }
+                if !ip.is_loopback() && !is_link_local_v6(&ip) && ipv6.is_none() {
+                    ipv6 = Some(ip.to_string());
                 }
             }
         }
@@ -804,19 +801,15 @@ mod tests {
 
     #[test]
     fn freebsd_picks_ipv4_default_iface() {
-        let iface = parse_default_iface_from_netstat_json(
-            NETSTAT_SEPARATE_IFACES,
-            Some(IpFamily::V4),
-        );
+        let iface =
+            parse_default_iface_from_netstat_json(NETSTAT_SEPARATE_IFACES, Some(IpFamily::V4));
         assert_eq!(iface.as_deref(), Some("em0"));
     }
 
     #[test]
     fn freebsd_picks_ipv6_default_iface() {
-        let iface = parse_default_iface_from_netstat_json(
-            NETSTAT_SEPARATE_IFACES,
-            Some(IpFamily::V6),
-        );
+        let iface =
+            parse_default_iface_from_netstat_json(NETSTAT_SEPARATE_IFACES, Some(IpFamily::V6));
         assert_eq!(iface.as_deref(), Some("em1"));
     }
 

--- a/src/tui/charts.rs
+++ b/src/tui/charts.rs
@@ -152,7 +152,10 @@ fn render_metrics_text<'a>(
         if let Some(l) = loss {
             spans.push(Span::raw(" "));
             spans.push(Span::styled("loss", Style::default().fg(Color::Gray)));
-            spans.push(Span::styled(format!(" {:.1}%", l * 100.0), Style::default().fg(c)));
+            spans.push(Span::styled(
+                format!(" {:.1}%", l * 100.0),
+                Style::default().fg(c),
+            ));
         }
         Line::from(spans)
     } else {
@@ -171,6 +174,7 @@ fn render_metrics_text<'a>(
 }
 
 /// Helper function to render a throughput chart with metrics inside the same bordered box
+#[allow(clippy::too_many_arguments)]
 pub fn render_chart_with_metrics_inside(
     f: &mut Frame,
     area: Rect,
@@ -315,7 +319,7 @@ pub fn draw_charts(area: Rect, f: &mut Frame, state: &UiState) {
     // Chart width = chunks[1].width - Y-axis label width (6) - borders (2)
     let available_chart_width = chunks[1].width.saturating_sub(8) as usize;
     // Cap at 200 bars max for performance, but allow wider bars on ultra-wide screens
-    let max_bars = available_chart_width.max(1).min(200);
+    let max_bars = available_chart_width.clamp(1, 200);
 
     // Prepare data for charts: take only as many as can fit, then reverse so oldest is on left, newest on right
     let data_points: Vec<_> = filtered_data
@@ -383,11 +387,9 @@ pub fn draw_charts(area: Rect, f: &mut Frame, state: &UiState) {
 
     // Recalculate bar width for the actual chart area
     let dl_chart_width = dl_layout[1].width.saturating_sub(2) as usize;
-    let dl_bar_width = if num_bars > 0 {
-        (dl_chart_width / num_bars).max(1) as u16
-    } else {
-        1
-    };
+    let dl_bar_width = dl_chart_width
+        .checked_div(num_bars)
+        .map_or(1, |w| w.max(1) as u16);
 
     // Y-axis labels for download - offset by 1 at top/bottom to align with chart's inner area
     let dl_label_layout = Layout::default()
@@ -442,11 +444,9 @@ pub fn draw_charts(area: Rect, f: &mut Frame, state: &UiState) {
 
     // Recalculate bar width for upload chart area
     let ul_chart_width = ul_layout[1].width.saturating_sub(2) as usize;
-    let ul_bar_width = if num_bars > 0 {
-        (ul_chart_width / num_bars).max(1) as u16
-    } else {
-        1
-    };
+    let ul_bar_width = ul_chart_width
+        .checked_div(num_bars)
+        .map_or(1, |w| w.max(1) as u16);
 
     // Y-axis labels for upload - offset by 1 at top/bottom to align with chart's inner area
     let ul_label_layout = Layout::default()

--- a/src/tui/dashboard/compact.rs
+++ b/src/tui/dashboard/compact.rs
@@ -80,15 +80,16 @@ pub fn draw_dashboard_compact(area: Rect, f: &mut Frame, state: &UiState) {
         .split(content[1]);
 
     // Idle latency stats text box
-    let idle_lat = if state.latency.idle_latency_samples.is_empty() && state.latency.idle_latency_sent == 0 {
-        None
-    } else {
-        Some(UiState::compute_live_latency_stats(
-            &state.latency.idle_latency_samples,
-            state.latency.idle_latency_sent,
-            state.latency.idle_latency_received,
-        ))
-    };
+    let idle_lat =
+        if state.latency.idle_latency_samples.is_empty() && state.latency.idle_latency_sent == 0 {
+            None
+        } else {
+            Some(UiState::compute_live_latency_stats(
+                &state.latency.idle_latency_samples,
+                state.latency.idle_latency_sent,
+                state.latency.idle_latency_received,
+            ))
+        };
     let format_latency = |lat: &crate::model::LatencySummary| -> Vec<Line> {
         vec![
             Line::from(vec![
@@ -132,7 +133,13 @@ pub fn draw_dashboard_compact(area: Rect, f: &mut Frame, state: &UiState) {
         ]),
         Line::from(vec![
             Span::styled("Interface: ", Style::default().fg(Color::Gray)),
-            Span::raw(show_or_redact(state.network.interface_name.as_deref(), state.hide_network_info).to_string()),
+            Span::raw(
+                show_or_redact(
+                    state.network.interface_name.as_deref(),
+                    state.hide_network_info,
+                )
+                .to_string(),
+            ),
             Span::raw(" ("),
             Span::raw(if state.network.is_wireless.unwrap_or(false) {
                 "Wireless"
@@ -150,7 +157,7 @@ pub fn draw_dashboard_compact(area: Rect, f: &mut Frame, state: &UiState) {
                     .network
                     .network_name
                     .as_deref()
-                    .or_else(|| state.network.interface_name.as_deref())
+                    .or(state.network.interface_name.as_deref())
                     .unwrap_or("-")
                     .to_string()
             }),
@@ -212,13 +219,22 @@ pub fn draw_dashboard_compact(area: Rect, f: &mut Frame, state: &UiState) {
         .and_then(|r| r.experimental_udp.as_ref())
     {
         let label_color = quality_label_color(&exp.quality_label);
-        let mos_str = exp.mos.map(|m| format!(" MOS {:.1}", m)).unwrap_or_default();
+        let mos_str = exp
+            .mos
+            .map(|m| format!(" MOS {:.1}", m))
+            .unwrap_or_default();
         meta_lines.push(Line::from(vec![
             Span::styled("UDP: ", Style::default().fg(Color::Gray)),
             Span::styled(&exp.quality_label, Style::default().fg(label_color)),
             Span::styled(mos_str, Style::default().fg(label_color)),
-            Span::styled(format!(" loss {:.1}%", exp.latency.loss * 100.0), Style::default().fg(Color::Yellow)),
-            Span::styled(format!(" reorder {:.1}%", exp.out_of_order_pct), Style::default().fg(Color::Gray)),
+            Span::styled(
+                format!(" loss {:.1}%", exp.latency.loss * 100.0),
+                Style::default().fg(Color::Yellow),
+            ),
+            Span::styled(
+                format!(" reorder {:.1}%", exp.out_of_order_pct),
+                Style::default().fg(Color::Gray),
+            ),
         ]));
         meta_lines.push(udp_split_bar(exp.latency.sent, exp.latency.received, 12));
     }
@@ -242,10 +258,12 @@ pub fn draw_dashboard_compact(area: Rect, f: &mut Frame, state: &UiState) {
             .borders(Borders::ALL)
             .title("Network Information")
             .title_bottom(
-                Line::from(Span::styled(hide_hint, Style::default().fg(Color::DarkGray)))
-                    .right_aligned(),
+                Line::from(Span::styled(
+                    hide_hint,
+                    Style::default().fg(Color::DarkGray),
+                ))
+                .right_aligned(),
             ),
     );
     f.render_widget(meta, bottom_row[1]);
 }
-

--- a/src/tui/dashboard/full.rs
+++ b/src/tui/dashboard/full.rs
@@ -14,9 +14,7 @@ use ratatui::{
 use super::super::charts;
 use super::super::log_style;
 use super::super::state::{push_wrapped_status_kv, UiState, REDACTED_PLACEHOLDER};
-use super::{
-    external_ip_for_family, max_y, quality_label_color, redact_log_line, show_or_redact,
-};
+use super::{external_ip_for_family, max_y, quality_label_color, redact_log_line, show_or_redact};
 
 pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
     let main = Layout::default()
@@ -42,8 +40,18 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
     // Download throughput chart (left) - only show when download phase has data
     if state.throughput.dl_phase_start.is_some() && !state.throughput.dl_points.is_empty() {
         // Calculate x bounds only for download points
-        let dl_x_max = state.throughput.dl_points.last().map(|(x, _)| *x).unwrap_or(0.0);
-        let dl_x_min = state.throughput.dl_points.first().map(|(x, _)| *x).unwrap_or(0.0);
+        let dl_x_max = state
+            .throughput
+            .dl_points
+            .last()
+            .map(|(x, _)| *x)
+            .unwrap_or(0.0);
+        let dl_x_min = state
+            .throughput
+            .dl_points
+            .first()
+            .map(|(x, _)| *x)
+            .unwrap_or(0.0);
 
         let y_dl_max = max_y(&state.throughput.dl_points).max(10.0);
         let y_dl_max = (y_dl_max * 1.10).min(10_000.0);
@@ -58,7 +66,9 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
         let dl_values: Vec<f64> = state.throughput.dl_points.iter().map(|(_, y)| *y).collect();
         let dl_metrics = crate::metrics::compute_sample_metrics(&dl_values);
         // Use the computed mean from metrics for the title to match what's shown below
-        let dl_avg = dl_metrics.map(|m| m.mean).unwrap_or(state.throughput.dl_avg_mbps);
+        let dl_avg = dl_metrics
+            .map(|m| m.mean)
+            .unwrap_or(state.throughput.dl_avg_mbps);
         let dl_title = Line::from(vec![
             Span::raw("Download (inst "),
             Span::styled(
@@ -104,8 +114,18 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
     // Upload throughput chart (right) - only show when upload phase has data
     if state.throughput.ul_phase_start.is_some() && !state.throughput.ul_points.is_empty() {
         // Calculate x bounds only for upload points
-        let ul_x_max = state.throughput.ul_points.last().map(|(x, _)| *x).unwrap_or(0.0);
-        let ul_x_min = state.throughput.ul_points.first().map(|(x, _)| *x).unwrap_or(0.0);
+        let ul_x_max = state
+            .throughput
+            .ul_points
+            .last()
+            .map(|(x, _)| *x)
+            .unwrap_or(0.0);
+        let ul_x_min = state
+            .throughput
+            .ul_points
+            .first()
+            .map(|(x, _)| *x)
+            .unwrap_or(0.0);
 
         let y_ul_max = max_y(&state.throughput.ul_points).max(10.0);
         let y_ul_max = (y_ul_max * 1.10).min(10_000.0);
@@ -120,7 +140,9 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
         let ul_values: Vec<f64> = state.throughput.ul_points.iter().map(|(_, y)| *y).collect();
         let ul_metrics = crate::metrics::compute_sample_metrics(&ul_values);
         // Use the computed mean from metrics for the title to match what's shown below
-        let ul_avg = ul_metrics.map(|m| m.mean).unwrap_or(state.throughput.ul_avg_mbps);
+        let ul_avg = ul_metrics
+            .map(|m| m.mean)
+            .unwrap_or(state.throughput.ul_avg_mbps);
         let ul_title = Line::from(vec![
             Span::raw("Upload (inst "),
             Span::styled(
@@ -202,9 +224,10 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
     // Download latency
     if !state.latency.loaded_dl_latency_samples.is_empty() {
         // Use the same median calculation as the metrics below
-        let median = crate::metrics::compute_sample_metrics(&state.latency.loaded_dl_latency_samples)
-            .map(|m| m.median)
-            .unwrap_or(f64::NAN);
+        let median =
+            crate::metrics::compute_sample_metrics(&state.latency.loaded_dl_latency_samples)
+                .map(|m| m.median)
+                .unwrap_or(f64::NAN);
         let jitter = crate::metrics::compute_jitter(&state.latency.loaded_dl_latency_samples);
         let title = Line::from(vec![
             Span::raw("Latency Download ("),
@@ -235,9 +258,10 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
     // Upload latency
     if !state.latency.loaded_ul_latency_samples.is_empty() {
         // Use the same median calculation as the metrics below
-        let median = crate::metrics::compute_sample_metrics(&state.latency.loaded_ul_latency_samples)
-            .map(|m| m.median)
-            .unwrap_or(f64::NAN);
+        let median =
+            crate::metrics::compute_sample_metrics(&state.latency.loaded_ul_latency_samples)
+                .map(|m| m.median)
+                .unwrap_or(f64::NAN);
         let jitter = crate::metrics::compute_jitter(&state.latency.loaded_ul_latency_samples);
         let title = Line::from(vec![
             Span::raw("Latency Upload ("),
@@ -309,7 +333,10 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
     {
         f.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled("Packet loss probe failed: ", Style::default().fg(Color::Gray)),
+                Span::styled(
+                    "Packet loss probe failed: ",
+                    Style::default().fg(Color::Gray),
+                ),
                 Span::styled(err.as_str(), Style::default().fg(Color::Yellow)),
             ])),
             udp_inner,
@@ -332,7 +359,11 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
             .map(|exp| {
                 let label = exp.quality_label.as_str();
                 let mos = exp.mos.map(|m| format!("MOS {:.1}", m)).unwrap_or_default();
-                let jitter = exp.latency.jitter_ms.map(|j| format!("jitter {:.1}ms", j)).unwrap_or_default();
+                let jitter = exp
+                    .latency
+                    .jitter_ms
+                    .map(|j| format!("jitter {:.1}ms", j))
+                    .unwrap_or_default();
                 let reorder = format!("reorder {:.1}%", exp.out_of_order_pct);
                 (label, mos, jitter, reorder)
             })
@@ -379,11 +410,14 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
 
         // Ensure any loss shows at least one red segment
         let lost_units = if lost > 0 {
-            ((lost as f64 / safe_total as f64) * bar_width as f64).ceil().max(1.0) as usize
+            ((lost as f64 / safe_total as f64) * bar_width as f64)
+                .ceil()
+                .max(1.0) as usize
         } else {
             0
         };
-        let recv_units = ((safe_received as f64 / safe_total as f64) * bar_width as f64).floor() as usize;
+        let recv_units =
+            ((safe_received as f64 / safe_total as f64) * bar_width as f64).floor() as usize;
         let pending_units = bar_width.saturating_sub(recv_units + lost_units);
 
         let bar_recv = "█".repeat(recv_units);
@@ -398,7 +432,10 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
         // Show quality label and MOS when test is complete
         if !quality_label.is_empty() {
             let label_color = quality_label_color(quality_label);
-            spans.push(Span::styled(quality_label, Style::default().fg(label_color)));
+            spans.push(Span::styled(
+                quality_label,
+                Style::default().fg(label_color),
+            ));
             if !mos_str.is_empty() {
                 spans.push(Span::raw(" ("));
                 spans.push(Span::styled(&mos_str, Style::default().fg(label_color)));
@@ -411,7 +448,13 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
         spans.extend(vec![
             Span::styled(
                 loss_str,
-                Style::default().fg(if udp_loss_pct == 0.0 { Color::Green } else if udp_loss_pct < 2.5 { Color::Yellow } else { Color::Red }),
+                Style::default().fg(if udp_loss_pct == 0.0 {
+                    Color::Green
+                } else if udp_loss_pct < 2.5 {
+                    Color::Yellow
+                } else {
+                    Color::Red
+                }),
             ),
             Span::raw(" "),
             Span::styled(rtt_display, Style::default().fg(Color::Gray)),
@@ -439,13 +482,13 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
         ]);
 
         if pending > 0 {
-            spans.push(Span::styled(format!(" pending {}", pending), Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled(
+                format!(" pending {}", pending),
+                Style::default().fg(Color::DarkGray),
+            ));
         }
 
-        f.render_widget(
-            Paragraph::new(Line::from(spans)),
-            udp_inner,
-        );
+        f.render_widget(Paragraph::new(Line::from(spans)), udp_inner);
     } else {
         let msg = if state.phase == crate::model::Phase::PacketLoss {
             "Packet loss probe starting..."
@@ -492,7 +535,7 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
             .network
             .network_name
             .as_deref()
-            .or_else(|| state.network.interface_name.as_deref())
+            .or(state.network.interface_name.as_deref())
             .unwrap_or("-")
             .to_string()
     };
@@ -557,9 +600,15 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
             Style::default().fg(Color::Cyan),
         ));
     } else {
-        match (state.network.as_org.as_deref(), state.network.asn.as_deref()) {
+        match (
+            state.network.as_org.as_deref(),
+            state.network.asn.as_deref(),
+        ) {
             (Some(org), Some(asn)) => {
-                your_network.push(Span::styled(org.to_string(), Style::default().fg(Color::Cyan)));
+                your_network.push(Span::styled(
+                    org.to_string(),
+                    Style::default().fg(Color::Cyan),
+                ));
                 your_network.push(Span::raw(" ("));
                 your_network.push(Span::styled(
                     format!("AS{}", asn),
@@ -568,7 +617,10 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
                 your_network.push(Span::raw(")"));
             }
             (Some(org), None) => {
-                your_network.push(Span::styled(org.to_string(), Style::default().fg(Color::Cyan)));
+                your_network.push(Span::styled(
+                    org.to_string(),
+                    Style::default().fg(Color::Cyan),
+                ));
             }
             (None, Some(asn)) => {
                 your_network.push(Span::styled(
@@ -683,10 +735,7 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
             };
             network_lines.push(Line::from(vec![
                 Span::styled("Traceroute: ", Style::default().fg(Color::Gray)),
-                Span::styled(
-                    tr.hops.len().to_string(),
-                    Style::default().fg(Color::Cyan),
-                ),
+                Span::styled(tr.hops.len().to_string(), Style::default().fg(Color::Cyan)),
                 Span::styled(" hops (", Style::default().fg(Color::Gray)),
                 Span::styled(status, Style::default().fg(status_color)),
                 Span::styled(")", Style::default().fg(Color::Gray)),
@@ -715,8 +764,11 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
             .borders(Borders::ALL)
             .title("Network Information")
             .title_bottom(
-                Line::from(Span::styled(hide_hint, Style::default().fg(Color::DarkGray)))
-                    .right_aligned(),
+                Line::from(Span::styled(
+                    hide_hint,
+                    Style::default().fg(Color::DarkGray),
+                ))
+                .right_aligned(),
             ),
     );
     f.render_widget(network_info, info_row[0]);
@@ -742,8 +794,11 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
         .borders(Borders::ALL)
         .title(title)
         .title_bottom(
-            Line::from(Span::styled(hide_hint, Style::default().fg(Color::DarkGray)))
-                .right_aligned(),
+            Line::from(Span::styled(
+                hide_hint,
+                Style::default().fg(Color::DarkGray),
+            ))
+            .right_aligned(),
         );
     let inner = panel.inner(info_row[1]);
     let visible_rows = inner.height as usize;
@@ -878,4 +933,3 @@ pub fn draw_dashboard_full(area: Rect, f: &mut Frame, state: &UiState) {
         Paragraph::new(status_lines).block(Block::default().borders(Borders::ALL).title("Status"));
     f.render_widget(status, main[4]);
 }
-

--- a/src/tui/dashboard/mod.rs
+++ b/src/tui/dashboard/mod.rs
@@ -11,7 +11,7 @@ use std::borrow::Cow;
 /// Returns `REDACTED_PLACEHOLDER` when `hide` is true, otherwise `value` or `"-"` for `None`.
 /// Used to conceal identifying network info (IP, MAC, SSID, ISP, location) for
 /// screenshot/demo sharing without altering stored history.
-pub(super) fn show_or_redact<'a>(value: Option<&'a str>, hide: bool) -> &'a str {
+pub(super) fn show_or_redact(value: Option<&str>, hide: bool) -> &str {
     if hide {
         REDACTED_PLACEHOLDER
     } else {
@@ -181,7 +181,9 @@ pub(super) fn udp_split_bar(sent: u64, received: u64, width: usize) -> Line<'sta
     let lost = safe_sent.saturating_sub(safe_received);
     // Ensure any loss shows at least one red segment
     let lost_units = if lost > 0 {
-        (width as f64 * lost as f64 / safe_sent as f64).ceil().max(1.0) as usize
+        (width as f64 * lost as f64 / safe_sent as f64)
+            .ceil()
+            .max(1.0) as usize
     } else {
         0
     };
@@ -196,7 +198,10 @@ pub(super) fn udp_split_bar(sent: u64, received: u64, width: usize) -> Line<'sta
         Span::styled(ok_part, Style::default().fg(Color::Green)),
         Span::styled(lost_part, Style::default().fg(Color::Red)),
         Span::raw("] "),
-        Span::styled(format!("ok {} lost {}", safe_received, lost), Style::default().fg(Color::Gray)),
+        Span::styled(
+            format!("ok {} lost {}", safe_received, lost),
+            Style::default().fg(Color::Gray),
+        ),
     ])
 }
 
@@ -210,7 +215,6 @@ pub(super) fn quality_label_color(label: &str) -> Color {
         _ => Color::Gray,
     }
 }
-
 
 mod compact;
 mod full;
@@ -263,7 +267,10 @@ mod tests {
     fn external_ip_ignores_meta_ip_of_other_family() {
         // --ipv6-only: the v4 probe is skipped and the meta client IP is the
         // IPv6 address; it must not appear on the IPv4 row (issue #49).
-        assert_eq!(external_ip_for_family(None, Some("2001:db8::1"), true), None);
+        assert_eq!(
+            external_ip_for_family(None, Some("2001:db8::1"), true),
+            None
+        );
         assert_eq!(external_ip_for_family(None, Some("1.2.3.4"), false), None);
     }
 

--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -128,9 +128,8 @@ fn init_clipboard_manager() -> Result<&'static std_mpsc::Sender<String>> {
             #[cfg(target_os = "android")]
             for _ in rx {
                 // Clipboard not supported on Android.
-             }
-        }
-        );
+            }
+        });
 
         tx
     });
@@ -148,9 +147,7 @@ pub fn copy_to_clipboard(text: &str) -> Result<()> {
     #[cfg(target_os = "android")]
     {
         let _ = text;
-        return Err(anyhow::anyhow!(
-            "Clipboard is not supported on Android"
-        ));
+        return Err(anyhow::anyhow!("Clipboard is not supported on Android"));
     }
 
     #[cfg(not(target_os = "android"))]

--- a/src/tui/log_style.rs
+++ b/src/tui/log_style.rs
@@ -74,12 +74,7 @@ fn highlight_numbers(s: &str, mbps_color: Color) -> Vec<Span<'static>> {
             // Identifier continuation: previous char in `buf` is a letter or
             // underscore. Absorb the digit run (incl. dots/underscores so we
             // keep "TLSv1_3" together) into the text buffer.
-            if buf
-                .chars()
-                .last()
-                .map(is_ident_char)
-                .unwrap_or(false)
-            {
+            if buf.chars().last().map(is_ident_char).unwrap_or(false) {
                 while i < chars.len() && (chars[i].is_ascii_digit() || chars[i] == '.') {
                     buf.push(chars[i]);
                     i += 1;
@@ -164,7 +159,13 @@ fn recognised_unit(rest: &str, mbps_color: Color) -> Option<(&'static str, usize
         ("%", "%", 1, PERCENT, false),
     ];
     for (prefix, unit, len, color, with_space) in cases.iter() {
-        if rest.starts_with(prefix) && !rest[prefix.len()..].chars().next().map(is_ident_char).unwrap_or(false) {
+        if rest.starts_with(prefix)
+            && !rest[prefix.len()..]
+                .chars()
+                .next()
+                .map(is_ident_char)
+                .unwrap_or(false)
+        {
             return Some((*unit, *len, *color, *with_space));
         }
     }
@@ -240,7 +241,10 @@ mod tests {
     #[test]
     fn still_highlights_standalone_metrics() {
         let line = "Download: 282.34 Mbps";
-        assert_eq!(highlighted_substrings(line), vec!["282.34 Mbps".to_string()]);
+        assert_eq!(
+            highlighted_substrings(line),
+            vec!["282.34 Mbps".to_string()]
+        );
 
         let line = "Packet loss probe: 50/100 recv 48 loss 4.0% (12.1ms)";
         let hl = highlighted_substrings(line);

--- a/src/tui/traceroute.rs
+++ b/src/tui/traceroute.rs
@@ -69,8 +69,8 @@ pub fn draw_traceroute(area: Rect, f: &mut Frame, state: &UiState) {
         ]));
     }
 
-    let widget = Paragraph::new(lines)
-        .block(Block::default().borders(Borders::ALL).title("Traceroute"));
+    let widget =
+        Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title("Traceroute"));
     f.render_widget(widget, area);
 }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -37,7 +37,7 @@ fn is_newer(latest: &str, current: &str) -> bool {
     let parse = |s: &str| -> (u32, u32, u32) {
         let parts: Vec<u32> = s.split('.').filter_map(|p| p.parse().ok()).collect();
         (
-            parts.get(0).copied().unwrap_or(0),
+            parts.first().copied().unwrap_or(0),
             parts.get(1).copied().unwrap_or(0),
             parts.get(2).copied().unwrap_or(0),
         )


### PR DESCRIPTION
Adding CI running tests, clippy, or fmt on PRs.

- New `ci.yml`: fmt check + clippy with `-D warnings` on Ubuntu; `cargo test` on Ubuntu and macOS; build-only on Windows (the test suite assumes Unix loopback interface names, so Windows tests need validation on a runner first).
- All actions pinned to commit SHAs rather than mutable tags (supply-chain hardening; tags on third-party actions can be repointed).
- Fixes the clippy warnings and fmt drift in the files this PR touches; CI badge added to the README; `/worktrees/` gitignored.